### PR TITLE
✨ feat: 공통 토스트 메시지 컴포넌트 구현 및 모달 상단 위치 고정

### DIFF
--- a/src/common/CommonModal.tsx
+++ b/src/common/CommonModal.tsx
@@ -1,15 +1,16 @@
-import { type ReactNode } from 'react'
+import { type PropsWithChildren } from 'react'
 import { IoIosClose } from 'react-icons/io'
-import ModalWrapper from './ModalWrapper'
+import ModalWrapper from '@/common/ModalWrapper'
 
-interface CommonModalProps {
+interface CommonModalBaseProps {
   isOpen: boolean
   onClose: () => void
   title: string
   subtitle?: string
-  children: ReactNode
   className?: string
 }
+
+type CommonModalProps = PropsWithChildren<CommonModalBaseProps>
 
 export default function CommonModal({
   isOpen,

--- a/src/common/CommonModal.tsx
+++ b/src/common/CommonModal.tsx
@@ -22,19 +22,23 @@ export default function CommonModal({
   if (!isOpen) return null
 
   return (
-    <ModalWrapper className={className}> 
+    <ModalWrapper className={className}>
       {/* X 버튼 */}
       <button
-        className="absolute top-4 right-4 text-[#BDBDBD] text-xl"
+        className="absolute top-4 right-4 text-[#BDBDBD] text-xl cursor-pointer"
         onClick={onClose}
       >
         <IoIosClose />
       </button>
 
       {/* 타이틀 */}
-      <h2 className="text-center text-[24px] font-bold text-[#8349FF]">{title}</h2>
+      <h2 className="text-center mt-[20px] text-[24px] font-bold text-[#8349FF]">
+        {title}
+      </h2>
       {subtitle && (
-        <p className="mt-2 text-center text-[16px] text-[#BDBDBD]">{subtitle}</p>
+        <p className="mt-[8px] text-center text-[16px] text-[#BDBDBD]">
+          {subtitle}
+        </p>
       )}
 
       {/* 콘텐츠 */}

--- a/src/common/ModalWrapper.tsx
+++ b/src/common/ModalWrapper.tsx
@@ -9,12 +9,12 @@ interface ModalWrapperProps {
 const ModalWrapper: React.FC<ModalWrapperProps> = ({
   children,
   width = 'w-[396px]',
-  className = '', 
+  className = '',
 }) => {
   return (
     <div className="fixed inset-0 bg-[rgba(18,18,18,0.6)] z-50 flex justify-center items-center">
       <div
-        className={`bg-white ${width} rounded-xl p-[24px] relative flex flex-col items-center ${className}`} 
+        className={`bg-white ${width} rounded-xl p-[24px] relative flex flex-col items-center ${className}`}
       >
         {children}
       </div>

--- a/src/common/ModalWrapper.tsx
+++ b/src/common/ModalWrapper.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 interface ModalWrapperProps {
   children: React.ReactNode // 모달 내부 콘텐츠
   width?: string // 모달 너비 (Tailwind 클래스로 전달)
-  className?: string // ✅ 외부에서 전달받은 커스텀 스타일
+  className?: string // 외부에서 전달받은 커스텀 스타일
 }
 
 const ModalWrapper: React.FC<ModalWrapperProps> = ({

--- a/src/common/TestModal.tsx
+++ b/src/common/TestModal.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import CommonModal from '../common/CommonModal'
 import { cn } from '@/utils/cn'
+import ToastMessage from './ToastMessage'
 
 interface TestModalProps {
   isOpen: boolean
@@ -7,6 +9,12 @@ interface TestModalProps {
 }
 
 const TestModal = ({ isOpen, onClose }: TestModalProps) => {
+  const [showToast, setShowToast] = useState(false)
+
+  const handleConfirm = () => {
+    setShowToast(true)
+  }
+
   return (
     <CommonModal
       isOpen={isOpen}
@@ -14,14 +22,20 @@ const TestModal = ({ isOpen, onClose }: TestModalProps) => {
       title="테스트 모달"
       subtitle="공통 모달이 잘 뜨는지 확인!"
     >
+      {/* ToastMessage */}
+      {showToast && (
+        <ToastMessage
+          message="멤버로 확정 되었어요! 이제 함께 스터디를 시작할 수 있어요"
+          onClose={() => setShowToast(false)}
+          duration={3000}
+        />
+      )}
+
       <button
-        className={cn(
-          'px-4 py-2 text-white rounded',
-          'bg-[#8349FF]'
-        )}
-        onClick={onClose}
+        className={cn('px-4 py-2 text-white rounded', 'bg-[#8349FF]')}
+        onClick={handleConfirm}
       >
-        닫기
+        확인
       </button>
     </CommonModal>
   )

--- a/src/common/TestModal.tsx
+++ b/src/common/TestModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import CommonModal from '../common/CommonModal'
 import { cn } from '@/utils/cn'
-import ToastMessage from './ToastMessage'
+import ToastMessage from '@/common/ToastMessage'
+import CommonModal from '@/common/CommonModal'
 
 interface TestModalProps {
   isOpen: boolean

--- a/src/common/ToastMessage.tsx
+++ b/src/common/ToastMessage.tsx
@@ -5,14 +5,19 @@ import { IoCheckmarkCircle } from 'react-icons/io5'
 interface ToastMessageProps {
   message: string
   duration?: number
-  onClose?: () => void
+  onClose: () => void // 옵셔널 제거 → 필수로 변경
   className?: string
 }
 
-const ToastMessage = ({ message, duration = 3000, onClose, className }: ToastMessageProps) => {
+const ToastMessage = ({
+  message,
+  duration = 3000,
+  onClose,
+  className,
+}: ToastMessageProps) => {
   useEffect(() => {
     const timer = setTimeout(() => {
-      onClose?.()
+      onClose()
     }, duration)
     return () => clearTimeout(timer)
   }, [duration, onClose])

--- a/src/common/ToastMessage.tsx
+++ b/src/common/ToastMessage.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from 'react'
+import { cn } from '@/utils/cn'
+import { IoCheckmarkCircle } from 'react-icons/io5'
+
+interface ToastMessageProps {
+  message: string
+  duration?: number
+  onClose?: () => void
+  className?: string
+}
+
+const ToastMessage = ({ message, duration = 3000, onClose, className }: ToastMessageProps) => {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onClose?.()
+    }, duration)
+    return () => clearTimeout(timer)
+  }, [duration, onClose])
+
+  return (
+    <div
+      className={cn(
+        'absolute top-[-64px] left-1/2 -translate-x-1/2 z-50',
+        'inline-flex items-center h-[48px] rounded-lg bg-white shadow-md px-4 gap-2',
+        className
+      )}
+    >
+      <div className="w-6 h-6 flex items-center justify-center rounded-full">
+        <IoCheckmarkCircle className="text-[#8E61FF] w-[24px] h-[24px]" />
+      </div>
+      <span className="text-sm text-gray-700 whitespace-nowrap">{message}</span>
+    </div>
+  )
+}
+
+export default ToastMessage


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #22 
- 작업요약 : 공통 토스트 메시지 컴포넌트 구현 및 모달 상단 위치 고정

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- ToastMessage 컴포넌트 구현 (3초 후 자동 사라짐)
- inline-flex + h-[48px] 적용으로 텍스트 길이에 맞는 가로 길이 + 고정 높이 설정
- TestModal에서 버튼 클릭 시 토스트 확인 가능

## 📸 스크린샷 (선택)
<img width="1710" height="938" alt="Toast" src="https://github.com/user-attachments/assets/8dd67a95-8e75-4004-a683-6d05c5f897f9" />

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
