### PR TITLE
✨ feat: 공통 버튼 컴포넌트 및 App.css 색상변수 추가

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,10 @@
 
 @theme {
   --color-primary: #8349ff; /* 메인색상 */
+  --color-secondary: #f9f5ff; /* 보조색상 */
   --color-primary-hover: #6b3acb; /* 메인색상 호버 */
+  --color-secondary-hover: #f2e9ff; /* 보조색상 호버 */
+  --color-secondary-textHover: #6e32ff; /* 보조색상 텍스트 호버 */
   --color-text: #121212; /* 기본 텍스트 색상 */
   --color-text2: #4d4d4d; /* 보조 텍스트 색상 (기본색상보다 조금 연함)*/
   --color-text3: #ffffff; /* 흰색 텍스트 색상 */

--- a/src/common/CommonButton.tsx
+++ b/src/common/CommonButton.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/utils/cn'
+
+const ButtonVariants = cva(
+  `rounded-[4px] px-4 py-2 text-sm font-medium transition-colors cursor-pointer h-[48px] w-full`,
+  {
+    variants: {
+      variant: {
+        primary: 'bg-primary text-text3 hover:bg-primary-hover',
+        secondary:
+          'bg-secondary text-primary hover:bg-secondary-hover hover:text-secondary-textHover',
+        grayStyle:
+          'bg-disabled-fill text-[#4d4d4d] border-disabled-text border-[1px] hover:bg-[#dedede]',
+        disabled:
+          'bg-disabled-fill text-disabled-text cursor-not-allowed border-disabled-text border-[1px]',
+      },
+      visualScale: {
+        default: 'px-2 py-1',
+        md: 'px-4 py-2',
+        lg: 'px-6 py-3 text-lg',
+        xl: 'px-8 py-4 text-xl',
+      },
+    },
+  }
+)
+
+interface ButtonProps extends VariantProps<typeof ButtonVariants> {
+  className?: string
+  children?: React.ReactNode
+  disabled?: boolean
+  visualScale?: 'default' | 'md' | 'lg' | 'xl'
+  onClick?: () => void
+}
+
+export default function CommonButton({
+  variant = 'primary',
+  visualScale = 'default',
+  children,
+  className,
+  disabled = false,
+  ...Props
+}: ButtonProps) {
+  return (
+    <button
+      disabled={disabled}
+      className={cn(ButtonVariants({ variant, visualScale }), className)}
+      {...Props}
+    >
+      {children && children}
+    </button>
+  )
+}

--- a/src/pages/auth/loginPage.tsx
+++ b/src/pages/auth/loginPage.tsx
@@ -1,3 +1,4 @@
+import CommonButton from '@/common/CommonButton'
 import TransientModal from '@/common/TransientModal'
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -26,6 +27,20 @@ export default function LoginPage() {
           onClose={() => setIsOpen(false)}
           type="start"
         ></TransientModal>
+      </div>
+      <div className="flex flex-col gap-2">
+        <CommonButton variant="primary">
+          <span>로그인</span>
+        </CommonButton>
+        <CommonButton variant="secondary">
+          <span>회원가입</span>
+        </CommonButton>
+        <CommonButton variant="grayStyle">
+          <span>회색 버튼</span>
+        </CommonButton>
+        <CommonButton variant="disabled" visualScale="md">
+          <span>비활성화 버튼</span>
+        </CommonButton>
       </div>
     </>
   )


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #10
- 작업요약 : 공통 버튼 컴포넌트 작성

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- variant 프롭으로 primary , secondary, grayStyle, disabled 에 따른 4가지 색상 버튼 생성가능
- visualScale 프롭으로 내부 padding 및 text 사이즈 defalt 및 md, lg, xl 로 설정가능.
- 버튼 크기는 높이 48px 및 너비 full size 기본이며 className 으로 작성하여 자유롭게 적용 가능하게 설정

## 📸 스크린샷 (선택)

<img width="459" height="158" alt="image" src="https://github.com/user-attachments/assets/29f6227a-682c-47ea-9165-0611df8ccb9d" />


- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
