### PR TITLE
✨ feat: StudyCard 공통 컴포넌트 레이아웃 구현

### DIFF
--- a/src/common/StudyCard.tsx
+++ b/src/common/StudyCard.tsx
@@ -1,0 +1,89 @@
+import { cn } from '@/utils/cn'
+import { IoHeartOutline } from 'react-icons/io5'
+import { HiOutlineUserGroup } from 'react-icons/hi2'
+import { BsClock } from 'react-icons/bs'
+
+interface StudyCardProps {
+  imageUrl: string
+  title: string
+  description: string
+  memberCount?: number
+  time?: string
+  showBookmarkIcon?: boolean
+  clickable?: boolean
+  thumbnailRatio?: string
+  className?: string // 외부에서 크기 커스터마이징 가능
+  variant?: 'horizontal' | 'vertical'
+  onClick?: () => void
+}
+
+const StudyCard = ({
+  imageUrl,
+  title,
+  description,
+  memberCount,
+  time,
+  className,
+  variant = 'vertical',
+  onClick,
+}: StudyCardProps) => {
+  const isVertical = variant === 'vertical'
+
+  return (
+    <div
+      onClick={onClick}
+      className={cn(
+        'cursor-pointer',
+        isVertical
+          ? 'w-full max-w-[360px] min-w-[260px]'
+          : 'w-full max-w-[440px]',
+        className
+      )}
+    >
+      {/* 이미지 */}
+      <div
+        className={cn(
+          'rounded-[8px] overflow-hidden',
+          isVertical ? 'w-full h-[360px]' : 'w-full h-[260px]'
+        )}
+      >
+        <img
+          src={imageUrl}
+          alt={title}
+          className="w-full h-full object-cover"
+        />
+      </div>
+
+      {/* 텍스트 영역 */}
+      <div className={cn('mt-[16px]')}>
+        <div className="flex justify-between items-start">
+          <p className="text-[18px] font-semibold text-[#121212] line-clamp-1">{title}</p>
+          <IoHeartOutline className="w-[24px] h-[24px] text-[#bdbdbd] shrink-0 mt-[1px]" />
+        </div>
+
+        <p className="text-[14px] text-[#121212] mt-[4px] text-left line-clamp-2">
+          {description}
+        </p>
+
+        {(memberCount || time) && (
+          <div className="flex items-center gap-4 text-sm text-[#bdbdbd] mt-[12px]">
+            {memberCount !== undefined && (
+              <div className="flex items-center gap-1">
+                <HiOutlineUserGroup className="w-[16px] h-[16px]" />
+                <span>{memberCount}/10</span>
+              </div>
+            )}
+            {time && (
+              <div className="flex items-center gap-1">
+                <BsClock className="w-[16px] h-[16px]" />
+                <span>{time}</span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default StudyCard

--- a/src/common/TestModal.tsx
+++ b/src/common/TestModal.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { cn } from '@/utils/cn'
 import ToastMessage from '@/common/ToastMessage'
 import CommonModal from '@/common/CommonModal'
+import StudyCard from '@/common/StudyCard'
+import defaultThumbnail from '@/assets/images/default-thumbnail.png'
 
 interface TestModalProps {
   isOpen: boolean
@@ -16,28 +18,54 @@ const TestModal = ({ isOpen, onClose }: TestModalProps) => {
   }
 
   return (
-    <CommonModal
-      isOpen={isOpen}
-      onClose={onClose}
-      title="테스트 모달"
-      subtitle="공통 모달이 잘 뜨는지 확인!"
-    >
-      {/* ToastMessage */}
-      {showToast && (
-        <ToastMessage
-          message="멤버로 확정 되었어요! 이제 함께 스터디를 시작할 수 있어요"
-          onClose={() => setShowToast(false)}
-          duration={3000}
-        />
-      )}
-
-      <button
-        className={cn('px-4 py-2 text-white rounded', 'bg-[#8349FF]')}
-        onClick={handleConfirm}
+    <>
+      {/* ✅ 모달 */}
+      <CommonModal
+        isOpen={isOpen}
+        onClose={onClose}
+        title="테스트 모달"
+        subtitle="공통 모달이 잘 뜨는지 확인!"
       >
-        확인
-      </button>
-    </CommonModal>
+        {showToast && (
+          <ToastMessage
+            message="멤버로 확정 되었어요! 이제 함께 스터디를 시작할 수 있어요"
+            onClose={() => setShowToast(false)}
+            duration={3000}
+          />
+        )}
+
+        <button
+          className={cn('px-4 py-2 text-white rounded mb-4', 'bg-[#8349FF]')}
+          onClick={handleConfirm}
+        >
+          확인
+        </button>
+      </CommonModal>
+
+    {/* vertical + 정사각형 이미지 + 사이즈 제어 */}
+    <div className='ml-[100px]'>
+    <StudyCard
+      imageUrl={defaultThumbnail}
+      title="정방향 카드"
+      description="설명 텍스트"
+      memberCount={4}
+      time="토요일 오후 5시"
+      variant="vertical"
+      className="max-w-[320px] min-w-[260px] "
+    />
+
+    {/* horizontal + 가로 이미지 + 사이즈 조절 */}
+    <StudyCard
+      imageUrl={defaultThumbnail}
+      title="가로형 카드"
+      description="설명 텍스트"
+      memberCount={8}
+      time="화요일 오후 2시"
+      variant="horizontal"
+      className="w-full max-w-[440px] min-w-[360px]"
+    />
+    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
StudyCard 공통 컴포넌트 레이아웃 구현

## ✅ PR 요약

- 관련 이슈 번호 : #32
- 작업요약 : StudyCard 공통 컴포넌트 레이아웃 구현
<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- horizontal/vertical 레이아웃 스타일 정확히 구분
- vertical: 이미지 정사각형(360x360), 텍스트/아이콘 간격 조정

## 📸 스크린샷 (선택)
<img width="1710" height="943" alt="card" src="https://github.com/user-attachments/assets/7af96f48-9954-4b40-996b-dd357a1baefa" />


## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
