### PR TITLE
✨ feat: 계정설정페이지 및 sidebar UI 작성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,7 @@ export default function App() {
           path="/auth/find-email/success"
           element={<FindEmailSuccessPage />}
         />
-        <Route path="auth/account-delete" element={<AccountDeletePage />} />
+        <Route path="/auth/account-delete" element={<AccountDeletePage />} />
 
         {/* 스터디 */}
         <Route path="/study/create" element={<StudyCreatePage />} />

--- a/src/components/Layout/MypageSidebar.tsx
+++ b/src/components/Layout/MypageSidebar.tsx
@@ -1,26 +1,56 @@
-import { Link } from 'react-router-dom'
+import { NavLink } from 'react-router-dom'
+import profileImage from '@/assets/images/default-profile.png'
+
+const menuItems = [
+  { path: '/mypage/account', label: '계정 설정' },
+  { path: '/mypage/planner', label: '스터디 플래너' },
+  { path: '/mypage/messages/inbox', label: '쪽지함' },
+]
 
 export default function MypageSidebar() {
   return (
-    <div className="flex flex-col text-white gap-[10px]">
-      <Link
-        className="bg-amber-600 rounded-[5px] w-[120px] h-[40px] flex items-center justify-center"
-        to="/mypage/account"
-      >
-        계정설정
-      </Link>
-      <Link
-        className="bg-amber-600 rounded-[5px] w-[120px] h-[40px] flex items-center justify-center"
-        to="/mypage/planner"
-      >
-        스터디 플래너
-      </Link>
-      <Link
-        className="bg-amber-600 rounded-[5px] w-[120px] h-[40px] flex items-center justify-center"
-        to="/mypage/messages/inbox"
-      >
-        쪽지함
-      </Link>
+    <div className="flex flex-col justify-center items-center gap-[45px] w-[272px] ml-[260px] mt-[88px]">
+      <div className="flex flex-col items-center gap-[23px] w-full">
+        <div className="w-full flex justify-between gap-[20px]">
+          <img
+            src={profileImage}
+            alt="유저프로필이미지"
+            className="rounded-full w-[80px]"
+          />
+          <div className="flex flex-col justify-center text-left w-full">
+            <div className="text-[20px]">뭉치면 주먹밥</div>
+            <div className="text-[15px] text-text4">example@onstudy.com</div>
+          </div>
+        </div>
+        <div className="flex w-full justify-around items-center text-[12px] h-[64px] border-primary border-[1px] px-[31px] rounded-[4px]">
+          <div className="flex flex-col items-center justify-center">
+            <div>총 공부시간</div>
+            <div className="text-text2 font-light">1234 시간</div>
+          </div>
+          <div className="h-[26px] border-[0.5px] border-primary scale-x-50 origin-left">
+            {/*세로줄 UI*/}
+          </div>
+          <div className="flex flex-col items-center justify-center">
+            <div>참여한 스터디</div>
+            <div className="text-text2 font-light">99+</div>
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-col gap-[40px] text-sm text-text font-medium self-start">
+        {menuItems.map(({ path, label }) => (
+          <NavLink
+            key={path}
+            to={path}
+            className={({ isActive }) =>
+              `text-[20px] transition-colors duration-150 ${
+                isActive ? 'text-primary font-bold' : 'text-[#BDBDBD]'
+              }`
+            }
+          >
+            {label}
+          </NavLink>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/Layout/MypageSidebar.tsx
+++ b/src/components/Layout/MypageSidebar.tsx
@@ -9,7 +9,7 @@ const menuItems = [
 
 export default function MypageSidebar() {
   return (
-    <div className="flex flex-col justify-center items-center gap-[45px] w-[272px] ml-[260px] mt-[88px]">
+    <div className="flex flex-col justify-start items-center gap-[45px] w-[272px] ml-[260px] mt-[88px]">
       <div className="flex flex-col items-center gap-[23px] w-full">
         <div className="w-full flex justify-between gap-[20px]">
           <img

--- a/src/pages/mypage/AccountSettingsPage.tsx
+++ b/src/pages/mypage/AccountSettingsPage.tsx
@@ -1,15 +1,115 @@
-import { Link } from 'react-router-dom'
+import InputField from '@/common/InputField'
+import CommonButton from '@/common/CommonButton'
+import { Link, useNavigate } from 'react-router-dom'
+import profileImage from '@/assets/images/default-profile.png'
+import { FaComment } from 'react-icons/fa'
+import { MdOutlineArrowForwardIos } from 'react-icons/md'
 
 export default function AccountSettingsPage() {
+  const navigate = useNavigate()
+
+  const handleSubmit = (_e: React.FormEvent<HTMLFormElement>) => {
+    // console.log('Form Data:', data)
+    // 여기에 회원가입 로직을 추가하세요
+    navigate('/auth/signup/terms') // 회원가입 성공 페이지로 이동
+  }
+
   return (
-    <>
-      <div className="text-2xl">계정 설정</div>
-      <Link
-        className="bg-amber-600 rounded-[5px] w-[120px] h-[40px] flex items-center justify-center"
-        to="/auth/account-delete"
-      >
-        회원 탈퇴
-      </Link>
-    </>
+    <div className="flex flex-col items-center justify-start bg-white mt-[88px] ml-[160px] pb-[20px]">
+      <div className="flex flex-col items-center justify-center gap-[72px] self-start">
+        <img
+          src={profileImage}
+          alt="유저프로필이미지"
+          className="rounded-full w-[96px] self-start"
+        />
+        <div className="flex flex-col items-center justify-center gap-[32px] w-[400px]">
+          <div className="text-[24px] font-semibold self-start">회원정보</div>
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col items-center justify-center gap-[40px] w-full"
+          >
+            <div className="flex flex-col pace-y-3 gap-[16px] w-full">
+              <InputField
+                className="w-full h-[48px] bg-disabled-fill placeholder:text-text4"
+                placeholder="스토빗"
+                type="text"
+                disabled
+              />
+
+              <InputField
+                className="w-full h-[48px] placeholder:text-text4 bg-disabled-fill"
+                placeholder="storbit@example.com"
+                type="email"
+                disabled
+              />
+
+              <div className="flex w-full gap-[4px]">
+                <InputField
+                  className="w-[284px] h-[48px] placeholder:text-text4"
+                  placeholder="닉네임"
+                  type="text"
+                />
+
+                <CommonButton
+                  type="button"
+                  variant="grayStyle"
+                  className="w-full text-[16px] "
+                >
+                  중복확인
+                </CommonButton>
+              </div>
+              <div className="flex w-full gap-[4px]">
+                <InputField
+                  className="w-[284px] h-[48px] placeholder:text-text4 bg-disabled-fill"
+                  placeholder="010-1234-5678"
+                  type="number"
+                  disabled
+                />
+                <CommonButton
+                  type="button"
+                  variant="grayStyle"
+                  className="w-full text-[16px]"
+                >
+                  변경
+                </CommonButton>
+              </div>
+
+              <InputField
+                className="w-full h-[48px] placeholder:text-text4"
+                placeholder="비밀번호"
+                type="password"
+              />
+            </div>
+          </form>
+        </div>
+        <div className="flex flex-col gap-[80px] w-full">
+          <div className="flex flex-col w-full gap-[32px]">
+            <div className="text-[24px] font-semibold">계정 연결하기</div>
+            <CommonButton
+              variant="grayStyle"
+              className="flex justify-between items-center w-full h-[56px] px-[16px] bg-white hover:bg-[#f8f5f5]"
+              onClick={() => {}}
+            >
+              <div className="flex items-center text-[16px] justify-center">
+                <FaComment className="mr-2 text-[#fee500]" />
+                <div>카카오톡으로 계정 연결하기</div>
+              </div>
+              <div className="flex items-center gap-[15px] text-disabled-text">
+                <MdOutlineArrowForwardIos className="text-[20px] text-text2" />
+              </div>
+            </CommonButton>
+          </div>
+          <div className="flex flex-col gap-[24px] items-center justify-center">
+            <CommonButton variant="disabled">변경내용 저장</CommonButton>
+            <Link
+              to="/auth/account-delete"
+              className="text-[16px] text-text1 underline"
+            >
+              회원탈퇴
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #46 
- 작업요약 : 계정설정페이지 sidebar와 회원정보 수정 페이지 UI 작성
- 
<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 계정설정페이지 sidebar UI
- sidebar에서 계정설정, 스터디플래너 , 쪽지함을 누르면 해당페이지로 이동
- 회원정보 수정 페이지 UI 


## 📸 스크린샷 (선택)

<img width="709" height="797" alt="image" src="https://github.com/user-attachments/assets/dd1cc03f-12dd-4246-b811-629ef296075f" />


## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
