### PR TITLE
✨ feat: 이벤트 전용 태그(EventTag) 컴포넌트 생성

### DIFF
--- a/src/common/StudyCard.tsx
+++ b/src/common/StudyCard.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/utils/cn'
 import { IoHeartOutline, IoHeartSharp } from 'react-icons/io5'
 import { HiOutlineUserGroup } from 'react-icons/hi2'
 import { BsClock } from 'react-icons/bs'
-import StudyTag from '@/common/StudyTag'
+import StudyTag from '@/common/tag/StudyTag'
 
 interface StudyCardProps {
   imageUrl: string
@@ -14,7 +14,7 @@ interface StudyCardProps {
   showBookmarkIcon?: boolean
   className?: string //외부에서 카드 전체 스타일을 확장할 때 사용 (Tailwind 클래스)
   variant?: 'horizontal' | 'vertical'
-  thumbnailRatio?: string //썸네일 이미지 영역의 크기를 커스터마이징할 때 사용 
+  thumbnailRatio?: string //썸네일 이미지 영역의 크기를 커스터마이징할 때 사용
   onClick?: () => void
 }
 

--- a/src/common/TestModal.tsx
+++ b/src/common/TestModal.tsx
@@ -4,6 +4,7 @@ import ToastMessage from '@/common/ToastMessage'
 import CommonModal from '@/common/CommonModal'
 import StudyCard from '@/common/StudyCard'
 import defaultThumbnail from '@/assets/images/default-thumbnail.png'
+import EventTag from './tag/EventTag'
 
 interface TestModalProps {
   isOpen: boolean
@@ -66,6 +67,7 @@ const TestModal = ({ isOpen, onClose }: TestModalProps) => {
           className=""
         />
       </div>
+      <EventTag status="진행중" date="~06.17" />
     </>
   )
 }

--- a/src/common/tag/EventTag.tsx
+++ b/src/common/tag/EventTag.tsx
@@ -1,0 +1,38 @@
+import { cn } from '@/utils/cn'
+import { FaRegCalendarAlt } from "react-icons/fa";
+
+interface EventTagProps {
+  status: string 
+  date: string  
+  className?: string
+}
+
+const EventTag = ({ status, date, className }: EventTagProps) => {
+  return (
+    <div className={cn('flex gap-[4px] items-center h-[24px]', className)}>
+      {/* 진행중 태그 */}
+      <span
+        className={cn(
+          'bg-[#F45D75] text-white text-[12px]',
+          'px-[4px] py-[4px] rounded-[4px]'
+        )}
+      >
+        {status}
+      </span>
+
+      {/* 날짜 태그 */}
+      <span
+        className={cn(
+          'flex items-center gap-[4px] border border-[#F45D75]',
+          'text-[#F45D75] text-[12px]',
+          'px-[4px] py-[4px] rounded-[4px]'
+        )}
+      >
+        <FaRegCalendarAlt className="w-[16px] h-[16px]" />
+        {date}
+      </span>
+    </div>
+  )
+}
+
+export default EventTag

--- a/src/common/tag/StudyTag.tsx
+++ b/src/common/tag/StudyTag.tsx
@@ -6,18 +6,15 @@ interface StudyTagProps {
 }
 
 const StudyTag = ({ variant, text }: StudyTagProps) => {
-  const baseStyle = 'text-[12px] p-[4px] h-[24px] rounded-[4px] flex items-center justify-center'
+  const baseStyle =
+    'text-[12px] p-[4px] h-[24px] rounded-[4px] flex items-center justify-center'
 
   const styleMap = {
     level: 'text-[#8349FF] border border-[#8349FF] bg-white',
     category: 'text-[#121212] bg-[#bdbdbd]',
   }
 
-  return (
-    <span className={cn(baseStyle, styleMap[variant])}>
-      {text}
-    </span>
-  )
+  return <span className={cn(baseStyle, styleMap[variant])}>{text}</span>
 }
 
 export default StudyTag


### PR DESCRIPTION
이벤트 전용 태그(EventTag) 컴포넌트 생성

## ✅ PR 요약

- 관련 이슈 번호 : #58
- 작업요약 : 이벤트용 상태 및 날짜 태그 UI를 구현한 EventTag 컴포넌트 생성

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 진행중/종료 상태 텍스트를 표시하는 핑크 배경 태그 추가
- 종료일(~06.17 등)을 캘린더 아이콘과 함께 표시하는 테두리형 태그 추가
- 두 태그를 하나의 라인에 배치하여 `gap-[4px]` 간격 유지
- 별도의 variant 없이 고정된 형태로 제공되는 복합 UI 전용 컴포넌트
- `flex`, `h-[24px]`, `rounded`, `text-[12px]` 등 디자인 가이드에 맞춰 구현

## 📸 스크린샷 (선택)

<img width="1710" height="943" alt="스크린샷 2025-08-01 오전 11 25 20" src="https://github.com/user-attachments/assets/ab63222e-cf6b-48bb-97bc-b3a15ccd9b11" />


## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
