### PR TITLE
✨ feat: 받은 쪽지함 UI 구현

### DIFF
--- a/src/components/Layout/MypageSidebar.tsx
+++ b/src/components/Layout/MypageSidebar.tsx
@@ -1,13 +1,23 @@
-import { NavLink } from 'react-router-dom'
+import { NavLink, useLocation } from 'react-router-dom'
 import profileImage from '@/assets/images/default-profile.png'
 
-const menuItems = [
+const MENUITEMS = [
   { path: '/mypage/account', label: '계정 설정' },
   { path: '/mypage/planner', label: '스터디 플래너' },
-  { path: '/mypage/messages/inbox', label: '쪽지함' },
-]
+  {
+    path: '/mypage/messages/inbox',
+    label: '쪽지함',
+    matchPaths: [
+      '/mypage/messages/inbox',
+      '/mypage/messages/sent',
+      '/mypage/messages/compose',
+    ],
+  },
+] as const
 
 export default function MypageSidebar() {
+  const location = useLocation()
+  const currentPath = location.pathname
   return (
     <div className="flex flex-col justify-start items-center gap-[45px] w-[272px] ml-[260px] mt-[88px]">
       <div className="flex flex-col items-center gap-[23px] w-full">
@@ -37,19 +47,28 @@ export default function MypageSidebar() {
         </div>
       </div>
       <div className="flex flex-col gap-[40px] text-sm text-text font-medium self-start">
-        {menuItems.map(({ path, label }) => (
-          <NavLink
-            key={path}
-            to={path}
-            className={({ isActive }) =>
-              `text-[20px] transition-colors duration-150 ${
-                isActive ? 'text-primary font-bold' : 'text-[#BDBDBD]'
-              }`
-            }
-          >
-            {label}
-          </NavLink>
-        ))}
+        {MENUITEMS.map((item) => {
+          const { path, label } = item
+
+          const isMatched =
+            ('matchPaths' in item
+              ? item.matchPaths.some((mp) => currentPath.startsWith(mp))
+              : false) || currentPath.startsWith(path)
+
+          return (
+            <NavLink
+              key={path}
+              to={path}
+              className={() =>
+                `text-[20px] transition-colors duration-150 ${
+                  isMatched ? 'text-primary font-bold' : 'text-[#BDBDBD]'
+                }`
+              }
+            >
+              {label}
+            </NavLink>
+          )
+        })}
       </div>
     </div>
   )

--- a/src/components/mypage/messageInboxPage/MessageDetail.tsx
+++ b/src/components/mypage/messageInboxPage/MessageDetail.tsx
@@ -1,0 +1,32 @@
+import CommonButton from '@/common/CommonButton'
+import { useInboxMessageStore } from '@/store/useInboxMessageStore'
+import type { Message } from '@/types/message'
+
+export default function MessageDetail({ message }: { message: Message }) {
+  const deleteInboxMessage = useInboxMessageStore(
+    (state) => state.deleteInboxMessage
+  )
+  return (
+    <div className="flex flex-col w-[664px] px-[60px] py-[40px] p-[24px] mt-[16px] h-[312px] border-[1px] border-primary rounded-[8px] text-[20px] cursor-pointer">
+      <div className="text-[24px]"> 보낸 내용</div>
+      <div className="text-text4 text-[15px] mt-[16px] flex-1">
+        {message.content}
+      </div>
+      <div className="flex gap-[4px] justify-end">
+        <CommonButton
+          variant="secondary"
+          className="border-[1px] border-primary"
+          onClick={() => {}}
+        >
+          재전송
+        </CommonButton>
+        <CommonButton
+          variant="primary"
+          onClick={() => deleteInboxMessage(message.id)}
+        >
+          삭제
+        </CommonButton>
+      </div>
+    </div>
+  )
+}

--- a/src/components/mypage/messageInboxPage/MessageList.tsx
+++ b/src/components/mypage/messageInboxPage/MessageList.tsx
@@ -1,11 +1,14 @@
-import { MdKeyboardArrowUp } from 'react-icons/md'
-// import { MdKeyboardArrowDown } from 'react-icons/md'
+import { MdKeyboardArrowUp, MdKeyboardArrowDown } from 'react-icons/md'
 import type { Message } from '@/types/message'
 import { useState } from 'react'
 import { cn } from '@/utils/cn'
+import MessageDetail from '@/components/mypage/messageInboxPage/MessageDetail'
 
 export default function MessageList({ messages }: { messages: Message[] }) {
   const [currentPage, setCurrentPage] = useState(1)
+  const [openSelectMessage, setOpenSelectMessage] = useState<string | null>(
+    null
+  )
   const itemsPerPage = 10
 
   const totalPages = Math.ceil(messages.length / itemsPerPage)
@@ -17,15 +20,26 @@ export default function MessageList({ messages }: { messages: Message[] }) {
   return (
     <div className="flex flex-col gap-[50px] pb-[20px]">
       <div>
-        {paginatedMessages.map((message, index) => (
-          <div key={index} className="pt-[16px]">
-            <div className="flex w-[664px] p-[24px] gap-[16px] items-center h-[72px] border-[1px] border-primary rounded-[8px] text-[20px]">
+        {paginatedMessages.map((message) => (
+          <div key={message.id} className="pt-[16px]">
+            <button
+              className="flex w-[664px] p-[24px] gap-[16px] items-center h-[72px] border-[1px] border-primary rounded-[8px] text-[20px] cursor-pointer"
+              onClick={() => {
+                if (openSelectMessage !== message.id) {
+                  setOpenSelectMessage(message.id)
+                } else if (openSelectMessage) {
+                  setOpenSelectMessage(null)
+                } else {
+                  setOpenSelectMessage(message.id)
+                }
+              }}
+            >
               {message.type === 'personal' ? (
                 <>
                   <div className="min-w-[160px] text-left text-text1 font-semibold">
                     {message.sender}
                   </div>
-                  <div className="text-text2 w-[423px] font-light truncate">
+                  <div className="text-text2 w-[423px] font-light truncate text-left">
                     {message.content}
                   </div>
                 </>
@@ -34,16 +48,26 @@ export default function MessageList({ messages }: { messages: Message[] }) {
                   <div className="min-w-[160px] text-left text-text1 font-semibold">
                     [{message.titlePrefix}]
                   </div>
-                  <div className="text-text2 w-[423px] font-light truncate">
+                  <div className="text-text2 w-[423px] font-light truncate text-left">
                     {message.content}
                   </div>
                 </>
               )}
-              <MdKeyboardArrowUp
-                size={40}
-                className="text-disabled-text ml-auto"
-              />
-            </div>
+              {message.id === openSelectMessage ? (
+                <MdKeyboardArrowDown
+                  size={40}
+                  className="text-disabled-text ml-auto"
+                />
+              ) : (
+                <MdKeyboardArrowUp
+                  size={40}
+                  className="text-disabled-text ml-auto"
+                />
+              )}
+            </button>
+            {message.id === openSelectMessage && (
+              <MessageDetail message={message} />
+            )}
           </div>
         ))}
       </div>

--- a/src/components/mypage/messageInboxPage/MessageList.tsx
+++ b/src/components/mypage/messageInboxPage/MessageList.tsx
@@ -1,0 +1,68 @@
+import { MdKeyboardArrowUp } from 'react-icons/md'
+// import { MdKeyboardArrowDown } from 'react-icons/md'
+import type { Message } from '@/types/message'
+import { useState } from 'react'
+import { cn } from '@/utils/cn'
+
+export default function MessageList({ messages }: { messages: Message[] }) {
+  const [currentPage, setCurrentPage] = useState(1)
+  const itemsPerPage = 10
+
+  const totalPages = Math.ceil(messages.length / itemsPerPage)
+  const paginatedMessages = [...messages]
+    .slice()
+    .reverse()
+    .slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage)
+
+  return (
+    <div className="flex flex-col gap-[50px] pb-[20px]">
+      <div>
+        {paginatedMessages.map((message, index) => (
+          <div key={index} className="pt-[16px]">
+            <div className="flex w-[664px] p-[24px] gap-[16px] items-center h-[72px] border-[1px] border-primary rounded-[8px] text-[20px]">
+              {message.type === 'personal' ? (
+                <>
+                  <div className="min-w-[160px] text-left text-text1 font-semibold">
+                    {message.sender}
+                  </div>
+                  <div className="text-text2 w-[423px] font-light truncate">
+                    {message.content}
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="min-w-[160px] text-left text-text1 font-semibold">
+                    [{message.titlePrefix}]
+                  </div>
+                  <div className="text-text2 w-[423px] font-light truncate">
+                    {message.content}
+                  </div>
+                </>
+              )}
+              <MdKeyboardArrowUp
+                size={40}
+                className="text-disabled-text ml-auto"
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Pagination */}
+      <div className="flex justify-center gap-[16px]">
+        {Array.from({ length: totalPages }, (_, i) => (
+          <button
+            key={i + 1}
+            onClick={() => setCurrentPage(i + 1)}
+            className={cn(
+              'text-[20px] text-disabled-text cursor-pointer',
+              currentPage === i + 1 ? 'text-primary ' : ''
+            )}
+          >
+            {i + 1}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/mystudymockdata/InboxMessageData.ts
+++ b/src/mystudymockdata/InboxMessageData.ts
@@ -1,0 +1,148 @@
+import type { Message } from '@/types/message'
+
+export const inboxMockData: Message[] = [
+  {
+    type: 'notice',
+    titlePrefix: '업데이트',
+    title: '사이트 기능 개선 안내',
+    content: '새로운 북마크 기능이 추가되었습니다. 많은 이용 부탁드립니다.',
+    sentAt: '2025-07-27T17:10:00',
+  },
+  {
+    type: 'personal',
+    sender: '홍길동',
+    senderImage: '/images/users/user1.jpg',
+    content: '안녕하세요! 혹시 이번 주 스터디 일정 확정됐나요?',
+    sentAt: '2025-07-31T14:25:00',
+  },
+  {
+    type: 'notice',
+    titlePrefix: '알림',
+    title: '출석 체크 이벤트 종료',
+    content: '7월 출석 체크 이벤트가 종료되었습니다. 참여해주셔서 감사합니다!',
+    sentAt: '2025-07-22T20:00:00',
+  },
+  {
+    type: 'personal',
+    sender: '김영희',
+    senderImage: '/images/users/user2.jpg',
+    content: '자료 잘 받았습니다. 감사합니다!',
+    sentAt: '2025-07-31T10:12:00',
+  },
+  {
+    type: 'notice',
+    titlePrefix: '신규 기능',
+    title: '스터디 챌린지 오픈',
+    content:
+      '스터디 챌린지 기능이 새롭게 추가되었습니다. 지금 바로 참여해보세요!',
+    sentAt: '2025-07-25T14:55:00',
+  },
+  {
+    type: 'personal',
+    sender: '이철수',
+    senderImage: '/images/users/user3.jpg',
+    content: '다음 과제 관련해서 질문이 있습니다.',
+    sentAt: '2025-07-30T18:47:00',
+  },
+  {
+    type: 'personal',
+    sender: '박하늘',
+    senderImage: '/images/users/user4.jpg',
+    content: '오프라인 모임 일정 다시 한 번 알려주세요!',
+    sentAt: '2025-07-30T09:15:00',
+  },
+  {
+    type: 'notice',
+    titlePrefix: '공지',
+    title: '8월 스터디 운영 안내',
+    content: '8월부터 스터디 시간이 오후 7시로 변경됩니다. 참고 바랍니다.',
+    sentAt: '2025-07-31T08:00:00',
+  },
+  {
+    type: 'personal',
+    sender: '최민수',
+    senderImage: '/images/users/user5.jpg',
+    content: '오늘 회의는 몇 시에 시작하나요?',
+    sentAt: '2025-07-29T16:03:00',
+  },
+  {
+    type: 'personal',
+    sender: '정유진',
+    senderImage: '/images/users/user6.jpg',
+    content: '스터디 노션 정리 감사합니다~',
+    sentAt: '2025-07-29T12:00:00',
+  },
+  {
+    type: 'personal',
+    sender: '한서준',
+    senderImage: '/images/users/user7.jpg',
+    content: '코드 리뷰 부탁드립니다!',
+    sentAt: '2025-07-28T22:30:00',
+  },
+  {
+    type: 'personal',
+    sender: '이지은',
+    senderImage: '/images/users/user8.jpg',
+    content: '오늘 강의 내용 정말 유익했어요.',
+    sentAt: '2025-07-28T17:10:00',
+  },
+  {
+    type: 'personal',
+    sender: '장도연',
+    senderImage: '/images/users/user9.jpg',
+    content: '다음주 발표 자료 공유드릴게요.',
+    sentAt: '2025-07-27T08:45:00',
+  },
+  {
+    type: 'personal',
+    sender: '유재석',
+    senderImage: '/images/users/user10.jpg',
+    content: '스터디 장소 변경됐어요. 확인 부탁드려요.',
+    sentAt: '2025-07-26T19:20:00',
+  },
+  {
+    type: 'notice',
+    titlePrefix: '필독',
+    title: '커뮤니티 이용 수칙 개정 안내',
+    content:
+      '2025년 8월 1일부터 커뮤니티 이용 수칙이 변경됩니다. 자세한 사항은 공지사항 게시판을 참고해주세요.',
+    sentAt: '2025-07-30T12:30:00',
+  },
+  {
+    type: 'notice',
+    titlePrefix: '공지',
+    title: '휴가 기간 안내',
+    content:
+      '8월 10일부터 14일까지는 담당자가 휴가 중입니다. 쪽지 응답이 다소 늦어질 수 있습니다.',
+    sentAt: '2025-07-29T15:40:00',
+  },
+  {
+    type: 'notice',
+    titlePrefix: '이벤트',
+    title: '스터디 후기 이벤트 안내',
+    content: '8월 5일까지 후기 작성 시 추첨을 통해 기프티콘을 드립니다!',
+    sentAt: '2025-07-28T11:25:00',
+  },
+  {
+    type: 'notice',
+    titlePrefix: '공지',
+    title: '서버 점검 안내',
+    content: '7월 30일 오전 2시부터 3시까지 서버 점검이 예정되어 있습니다.',
+    sentAt: '2025-07-26T21:00:00',
+  },
+  {
+    type: 'notice',
+    titlePrefix: '안내',
+    title: '커뮤니티 앱 출시',
+    content:
+      '이제 모바일에서도 커뮤니티를 편리하게 이용하실 수 있습니다. 앱을 다운로드해보세요!',
+    sentAt: '2025-07-24T09:20:00',
+  },
+  {
+    type: 'notice',
+    titlePrefix: '중요',
+    title: '개인정보 보호 강화 안내',
+    content: '개인정보 관련 법령 변경에 따라 서비스 약관이 수정되었습니다.',
+    sentAt: '2025-07-23T13:30:00',
+  },
+]

--- a/src/mystudymockdata/InboxMessageData.ts
+++ b/src/mystudymockdata/InboxMessageData.ts
@@ -2,6 +2,7 @@ import type { Message } from '@/types/message'
 
 export const inboxMockData: Message[] = [
   {
+    id: '1',
     type: 'notice',
     titlePrefix: '업데이트',
     title: '사이트 기능 개선 안내',
@@ -9,6 +10,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-27T17:10:00',
   },
   {
+    id: '2',
     type: 'personal',
     sender: '홍길동',
     senderImage: '/images/users/user1.jpg',
@@ -16,6 +18,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-31T14:25:00',
   },
   {
+    id: '3',
     type: 'notice',
     titlePrefix: '알림',
     title: '출석 체크 이벤트 종료',
@@ -23,6 +26,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-22T20:00:00',
   },
   {
+    id: '4',
     type: 'personal',
     sender: '김영희',
     senderImage: '/images/users/user2.jpg',
@@ -30,6 +34,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-31T10:12:00',
   },
   {
+    id: '5',
     type: 'notice',
     titlePrefix: '신규 기능',
     title: '스터디 챌린지 오픈',
@@ -38,6 +43,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-25T14:55:00',
   },
   {
+    id: '6',
     type: 'personal',
     sender: '이철수',
     senderImage: '/images/users/user3.jpg',
@@ -45,6 +51,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-30T18:47:00',
   },
   {
+    id: '7',
     type: 'personal',
     sender: '박하늘',
     senderImage: '/images/users/user4.jpg',
@@ -52,6 +59,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-30T09:15:00',
   },
   {
+    id: '8',
     type: 'notice',
     titlePrefix: '공지',
     title: '8월 스터디 운영 안내',
@@ -59,6 +67,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-31T08:00:00',
   },
   {
+    id: '9',
     type: 'personal',
     sender: '최민수',
     senderImage: '/images/users/user5.jpg',
@@ -66,6 +75,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-29T16:03:00',
   },
   {
+    id: '10',
     type: 'personal',
     sender: '정유진',
     senderImage: '/images/users/user6.jpg',
@@ -73,6 +83,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-29T12:00:00',
   },
   {
+    id: '11',
     type: 'personal',
     sender: '한서준',
     senderImage: '/images/users/user7.jpg',
@@ -80,6 +91,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-28T22:30:00',
   },
   {
+    id: '12',
     type: 'personal',
     sender: '이지은',
     senderImage: '/images/users/user8.jpg',
@@ -87,6 +99,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-28T17:10:00',
   },
   {
+    id: '13',
     type: 'personal',
     sender: '장도연',
     senderImage: '/images/users/user9.jpg',
@@ -94,6 +107,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-27T08:45:00',
   },
   {
+    id: '14',
     type: 'personal',
     sender: '유재석',
     senderImage: '/images/users/user10.jpg',
@@ -101,6 +115,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-26T19:20:00',
   },
   {
+    id: '15',
     type: 'notice',
     titlePrefix: '필독',
     title: '커뮤니티 이용 수칙 개정 안내',
@@ -109,6 +124,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-30T12:30:00',
   },
   {
+    id: '16',
     type: 'notice',
     titlePrefix: '공지',
     title: '휴가 기간 안내',
@@ -117,6 +133,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-29T15:40:00',
   },
   {
+    id: '17',
     type: 'notice',
     titlePrefix: '이벤트',
     title: '스터디 후기 이벤트 안내',
@@ -124,6 +141,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-28T11:25:00',
   },
   {
+    id: '18',
     type: 'notice',
     titlePrefix: '공지',
     title: '서버 점검 안내',
@@ -131,6 +149,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-26T21:00:00',
   },
   {
+    id: '19',
     type: 'notice',
     titlePrefix: '안내',
     title: '커뮤니티 앱 출시',
@@ -139,6 +158,7 @@ export const inboxMockData: Message[] = [
     sentAt: '2025-07-24T09:20:00',
   },
   {
+    id: '20',
     type: 'notice',
     titlePrefix: '중요',
     title: '개인정보 보호 강화 안내',

--- a/src/pages/Layout/MessageLayout.tsx
+++ b/src/pages/Layout/MessageLayout.tsx
@@ -1,27 +1,36 @@
-import { Link, Outlet } from 'react-router'
+import { NavLink, Outlet } from 'react-router-dom'
 
 export default function MessageLayout() {
+  const baseStyle = 'text-[#bdbdbd] '
+  const activeStyle = 'text-text2' // 원하는 활성화 스타일
   return (
-    <div className="flex flex-col gap-[20px]">
-      <div className="flex gap-[10px] text-white">
-        <Link
-          className="bg-emerald-300 rounded-[5px] w-[100px] h-[30px] flex items-center justify-center"
-          to="/mypage/messages/inbox"
-        >
-          받은쪽지함
-        </Link>
-        <Link
-          className="bg-emerald-300 rounded-[5px] w-[100px] h-[30px] flex items-center justify-center"
-          to="/mypage/messages/sent"
-        >
-          보낸쪽지함
-        </Link>
-        <Link
-          className="bg-emerald-300 rounded-[5px] w-[100px] h-[30px] flex items-center justify-center"
-          to="/mypage/messages/compose"
-        >
-          쪽지보내기
-        </Link>
+    <div className="flex flex-col gap-[24px] mt-[88px] ml-[160px]">
+      <div className="flex justify-between items-center">
+        <div className="flex gap-[12px] text-[20px]">
+          <NavLink
+            to="/mypage/messages/inbox"
+            className={({ isActive }) => (isActive ? activeStyle : baseStyle)}
+          >
+            받은쪽지
+          </NavLink>
+          <div>|</div>
+          <NavLink
+            to="/mypage/messages/sent"
+            className={({ isActive }) => (isActive ? activeStyle : baseStyle)}
+          >
+            보낸쪽지
+          </NavLink>
+          <div>|</div>
+          <NavLink
+            to="/mypage/messages/compose"
+            className={({ isActive }) => (isActive ? activeStyle : baseStyle)}
+          >
+            쪽지보내기
+          </NavLink>
+        </div>
+        <div className="text-[16px] text-[#bdbdbd] cursor-pointer">
+          전체 삭제
+        </div>
       </div>
       <Outlet />
     </div>

--- a/src/pages/Layout/MessageLayout.tsx
+++ b/src/pages/Layout/MessageLayout.tsx
@@ -1,6 +1,14 @@
+import CommonButton from '@/common/CommonButton'
+import CommonModal from '@/common/CommonModal'
+import { useInboxMessageStore } from '@/store/useInboxMessageStore'
+import { useState } from 'react'
 import { NavLink, Outlet } from 'react-router-dom'
 
 export default function MessageLayout() {
+  const allRemoveInboxMessages = useInboxMessageStore(
+    (state) => state.allRemoveInboxMessages
+  )
+  const [isModalOpen, setIsModalOpen] = useState(false)
   const baseStyle = 'text-[#bdbdbd] '
   const activeStyle = 'text-text2' // 원하는 활성화 스타일
   return (
@@ -28,11 +36,40 @@ export default function MessageLayout() {
             쪽지보내기
           </NavLink>
         </div>
-        <div className="text-[16px] text-[#bdbdbd] cursor-pointer">
+        <button
+          className="text-[16px] text-[#bdbdbd] cursor-pointer"
+          onClick={() => setIsModalOpen(true)}
+        >
           전체 삭제
-        </div>
+        </button>
       </div>
       <Outlet />
+      <CommonModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        title="받은 쪽지함을 모두 삭제하시겠습니까?"
+        subtitle="확인 버튼 클릭 시 받은 쪽지함이 모두 삭제됩니다."
+        className="w-[420px]"
+      >
+        <div className="flex gap-[4px]">
+          <CommonButton
+            variant="primary"
+            onClick={() => {
+              allRemoveInboxMessages()
+              setIsModalOpen(false)
+            }}
+          >
+            확인
+          </CommonButton>
+          <CommonButton
+            variant="secondary"
+            className="border-[1px] border-primary"
+            onClick={() => setIsModalOpen(false)}
+          >
+            취소
+          </CommonButton>
+        </div>
+      </CommonModal>
     </div>
   )
 }

--- a/src/pages/Layout/MessageLayout.tsx
+++ b/src/pages/Layout/MessageLayout.tsx
@@ -1,16 +1,44 @@
 import CommonButton from '@/common/CommonButton'
 import CommonModal from '@/common/CommonModal'
 import { useInboxMessageStore } from '@/store/useInboxMessageStore'
+import type { CurrentMessagePageType } from '@/types/message'
 import { useState } from 'react'
-import { NavLink, Outlet } from 'react-router-dom'
+import { NavLink, Outlet, useLocation } from 'react-router-dom'
 
 export default function MessageLayout() {
   const allRemoveInboxMessages = useInboxMessageStore(
     (state) => state.allRemoveInboxMessages
   )
   const [isModalOpen, setIsModalOpen] = useState(false)
+
   const baseStyle = 'text-[#bdbdbd] '
-  const activeStyle = 'text-text2' // 원하는 활성화 스타일
+  const activeStyle = 'text-text2' // 활성화 스타일
+
+  const location = useLocation()
+
+  const getCurrentMessagePageType = (
+    pathname: string
+  ): CurrentMessagePageType => {
+    if (pathname === '/mypage/messages/inbox') return 'inbox'
+    if (pathname === '/mypage/messages/sent') return 'sent'
+    if (pathname === '/mypage/messages/compose') return 'compose'
+    return null
+  }
+  const currentPageState = getCurrentMessagePageType(location.pathname)
+
+  const handleDeleteAll = () => {
+    if (currentPageState === 'inbox') {
+      allRemoveInboxMessages()
+    } else if (currentPageState === 'sent') {
+      // 보낸쪽지함 삭제기능
+    } else if (currentPageState === 'compose') {
+      return
+    } else {
+      return
+    }
+    setIsModalOpen(false)
+  }
+
   return (
     <div className="flex flex-col gap-[24px] mt-[88px] ml-[160px]">
       <div className="flex justify-between items-center">
@@ -36,18 +64,20 @@ export default function MessageLayout() {
             쪽지보내기
           </NavLink>
         </div>
-        <button
-          className="text-[16px] text-[#bdbdbd] cursor-pointer"
-          onClick={() => setIsModalOpen(true)}
-        >
-          전체 삭제
-        </button>
+        {!(currentPageState === 'compose') && (
+          <button
+            className="text-[16px] text-[#bdbdbd] cursor-pointer"
+            onClick={() => setIsModalOpen(true)}
+          >
+            전체 삭제
+          </button>
+        )}
       </div>
       <Outlet />
       <CommonModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        title="받은 쪽지함을 모두 삭제하시겠습니까?"
+        title={`${currentPageState === 'inbox' ? '받은' : currentPageState === 'sent' ? '보낸' : ''} 쪽지함을 모두 삭제하시겠습니까?`}
         subtitle="확인 버튼 클릭 시 받은 쪽지함이 모두 삭제됩니다."
         className="w-[420px]"
       >
@@ -55,7 +85,7 @@ export default function MessageLayout() {
           <CommonButton
             variant="primary"
             onClick={() => {
-              allRemoveInboxMessages()
+              handleDeleteAll()
               setIsModalOpen(false)
             }}
           >

--- a/src/pages/mypage/MessageInboxPage.tsx
+++ b/src/pages/mypage/MessageInboxPage.tsx
@@ -1,3 +1,10 @@
+import MessageList from '@/components/mypage/messageInboxPage/MessageList'
+import { inboxMockData } from '@/mystudymockdata/InboxMessageData'
+
 export default function MessageInboxPage() {
-  return <div className="text-2xl">받은쪽지 페이지</div>
+  return (
+    <div className="flex flex-col gap-[12px] text-2xl">
+      <MessageList messages={inboxMockData} />
+    </div>
+  )
 }

--- a/src/pages/mypage/MessageInboxPage.tsx
+++ b/src/pages/mypage/MessageInboxPage.tsx
@@ -1,10 +1,11 @@
 import MessageList from '@/components/mypage/messageInboxPage/MessageList'
-import { inboxMockData } from '@/mystudymockdata/InboxMessageData'
+import { useInboxMessageStore } from '@/store/useInboxMessageStore'
 
 export default function MessageInboxPage() {
+  const inboxMessages = useInboxMessageStore((state) => state.inboxMessages)
   return (
     <div className="flex flex-col gap-[12px] text-2xl">
-      <MessageList messages={inboxMockData} />
+      <MessageList messages={inboxMessages} />
     </div>
   )
 }

--- a/src/store/useInboxMessageStore.ts
+++ b/src/store/useInboxMessageStore.ts
@@ -4,10 +4,17 @@ import { inboxMockData } from '@/mystudymockdata/InboxMessageData'
 
 interface InboxMessageState {
   inboxMessages: Message[]
+  deleteInboxMessage: (id: string) => void
   allRemoveInboxMessages: () => void
 }
 
 export const useInboxMessageStore = create<InboxMessageState>((set) => ({
   inboxMessages: inboxMockData,
+  deleteInboxMessage: (id) =>
+    set((state) => ({
+      inboxMessages: state.inboxMessages.filter(
+        (inboxMessage) => inboxMessage.id !== id
+      ),
+    })),
   allRemoveInboxMessages: () => set(() => ({ inboxMessages: [] })),
 }))

--- a/src/store/useInboxMessageStore.ts
+++ b/src/store/useInboxMessageStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+import type { Message } from '@/types/message'
+import { inboxMockData } from '@/mystudymockdata/InboxMessageData'
+
+interface InboxMessageState {
+  inboxMessages: Message[]
+  allRemoveInboxMessages: () => void
+}
+
+export const useInboxMessageStore = create<InboxMessageState>((set) => ({
+  inboxMessages: inboxMockData,
+  allRemoveInboxMessages: () => set(() => ({ inboxMessages: [] })),
+}))

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -1,5 +1,6 @@
 export type Message =
   | {
+      id: string
       type: 'personal'
       sender: string
       senderImage: string
@@ -7,6 +8,7 @@ export type Message =
       sentAt: string
     }
   | {
+      id: string
       type: 'notice'
       titlePrefix: string
       title: string

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -13,3 +13,5 @@ export type Message =
       content: string
       sentAt: string
     }
+
+export type CurrentMessagePageType = 'inbox' | 'sent' | 'compose' | null

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -1,0 +1,15 @@
+export type Message =
+  | {
+      type: 'personal'
+      sender: string
+      senderImage: string
+      content: string
+      sentAt: string
+    }
+  | {
+      type: 'notice'
+      titlePrefix: string
+      title: string
+      content: string
+      sentAt: string
+    }


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #63 
- 작업요약 : 받은 쪽지함 UI 구현

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 받은 쪽지함 UI 구현
- 페이지당 10개씩 렌더링 되며 페이지 네이션 적용하여 구현
- 전체 삭제 클릭시 받은 쪽지함 및 보낸 쪽지함에 해당하는 쪽지 삭제
- 받은쪽지 클릭시 세부 내용 확인 및 삭제 버튼 기능 구현

## 📸 스크린샷 (선택)
<img width="450" src="https://github.com/user-attachments/assets/1ac402da-764b-4ba3-8956-aed6a46b65b1"/>



## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
