### PR TITLE
✨ feat: 카테고리 페이지 레이아웃, 사이드 메뉴, 신규 스터디 슬라이드 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,8 @@ import NotFound from '@/pages/NotFound'
 import TermsOfServicePage from '@/pages/terms/TermsOfServicePage'
 import PrivacyPolicyPage from '@/pages/privacy/PrivacyPolicyPage'
 import ContactPage from '@/pages/contact/ContactPage'
+import CategoryPage from '@/pages/category/CategoryPage'
+import CategoryDetailPage from '@/pages/category/CategoryDetailPage'
 
 export default function App() {
   return (
@@ -57,6 +59,10 @@ export default function App() {
         />
         <Route path="/auth/account-delete" element={<AccountDeletePage />} />
 
+        {/*카테고리*/}
+        <Route path="/category/:category" element={<CategoryPage />} />
+        <Route path="/category/:category/:subcategory" element={<CategoryDetailPage />} />
+        
         {/* 스터디 */}
         <Route path="/study/create" element={<StudyCreatePage />} />
         <Route

--- a/src/components/Layout/CategoryMenu.tsx
+++ b/src/components/Layout/CategoryMenu.tsx
@@ -1,61 +1,61 @@
 interface CategoryItem {
-    title: string
-    items: string[]
+  title: string
+  items: string[]
+}
+
+interface CategoryMenuProps {
+  onCategorySelect?: (category: string, item: string) => void
+  onClose?: () => void
+}
+
+const categoryData: CategoryItem[] = [
+  { title: '언어', items: ['영어', '일본어'] },
+  { title: '자격증', items: ['전산/세무/회계', '컴퓨터활용능력'] },
+  { title: '디자인', items: ['포토샵/일러스트', '피그마'] },
+  { title: 'IT·프로그래밍', items: ['웹 개발', '게임 개발'] },
+  { title: '경영·마케팅', items: ['경영전략', '마케팅'] },
+  { title: '취미', items: ['영화', '독서'] },
+]
+
+export default function CategoryMenu({
+  onCategorySelect,
+  onClose,
+}: CategoryMenuProps) {
+  const handleItemClick = (categoryTitle: string, item: string) => {
+    onCategorySelect?.(categoryTitle, item)
+    onClose?.()
   }
-  
-  interface CategoryMenuProps {
-    onCategorySelect?: (category: string, item: string) => void
-    onClose?: () => void
+
+  const handleCategoryTitleClick = (categoryTitle: string) => {
+    onCategorySelect?.(categoryTitle, '')
+    onClose?.()
   }
-  
-  const categoryData: CategoryItem[] = [
-    { title: '언어', items: ['영어', '일본어'] },
-    { title: '자격증', items: ['전산회계', '컴활'] },
-    { title: '디자인', items: ['포토샵', '피그마'] },
-    { title: 'IT·프로그래밍', items: ['웹개발', '게임개발'] },
-    { title: '경영·마케팅', items: ['마케팅', '전략'] },
-    { title: '취미', items: ['영화', '독서'] },
-  ]
-  
-  export default function CategoryMenu({ 
-    onCategorySelect, 
-    onClose 
-  }: CategoryMenuProps) {
-    const handleItemClick = (categoryTitle: string, item: string) => {
-      onCategorySelect?.(categoryTitle, item)
-      onClose?.()
-    }
-  
-    const handleCategoryTitleClick = (categoryTitle: string) => {
-      onCategorySelect?.(categoryTitle, '')
-      onClose?.()
-    }
-  
-    return (
-      <div className="w-full bg-[#212429] text-white border-t border-white">
-        <div className="max-w-[1400px] mx-[124px] grid grid-cols-6 gap-[134px] p-[40px]">
-          {categoryData.map((category) => (
-            <div key={category.title}>
-              <h3 
-                className="font-semibold text-[20px] mb-[24px] cursor-pointer"
-                onClick={() => handleCategoryTitleClick(category.title)}
-              >
-                {category.title}
-              </h3>
-              <ul className="space-y-1">
-                {category.items.map((item) => (
-                  <li 
-                    key={item} 
-                    className="cursor-pointer"
-                    onClick={() => handleItemClick(category.title, item)}
-                  >
-                    {item}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
+
+  return (
+    <div className="w-full bg-[#212429] text-white border-t border-white">
+      <div className="max-w-[1400px] mx-[124px] grid grid-cols-6 gap-[134px] p-[40px]">
+        {categoryData.map((category) => (
+          <div key={category.title}>
+            <h3
+              className="font-semibold text-[20px] mb-[24px] cursor-pointer"
+              onClick={() => handleCategoryTitleClick(category.title)}
+            >
+              {category.title}
+            </h3>
+            <ul className="space-y-1">
+              {category.items.map((item) => (
+                <li
+                  key={item}
+                  className="cursor-pointer"
+                  onClick={() => handleItemClick(category.title, item)}
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
       </div>
-    )
-  }
+    </div>
+  )
+}

--- a/src/components/Layout/NavBar.tsx
+++ b/src/components/Layout/NavBar.tsx
@@ -16,7 +16,7 @@ export default function NavBar() {
 
   const handleCategorySelect = (category: string, item: string) => {
     if (item) {
-      // 특정 항목 선택 시 - 해당 항목 페이지로 이동 (검색이 아님)
+      // 특정 항목 선택 시 - 해당 항목 페이지로 이동
       navigate(`/study/${item}`)
     } else {
       // 카테고리 제목 선택 시 - 해당 카테고리 페이지로 이동
@@ -41,7 +41,7 @@ export default function NavBar() {
   }
 
   const navItemClass =
-    'transition-colors duration-200 hover:text-[#8349FF] hover:font-bold'
+    'transition-colors hover:text-[#8349FF] hover:font-bold'
 
   return (
     <div className="w-full bg-[#212429] text-white relative">
@@ -86,9 +86,11 @@ export default function NavBar() {
           >
             <button
               type="button"
-              className={`bg-transparent border-none text-inherit cursor-pointer transition-colors duration-200 ${
-                isCategoryOpen ? 'text-[#8349FF]' : ''
-              } hover:text-[#8349FF] hover:font-bold`}
+              className={`bg-transparent border-none cursor-pointer transition-colors duration-200 ${
+                isCategoryOpen 
+                  ? 'text-[#8349FF] font-bold' 
+                  : 'text-white hover:text-[#8349FF] hover:font-bold'
+              }`}
             >
               카테고리
             </button>

--- a/src/pages/category/CategoryDetailPage.tsx
+++ b/src/pages/category/CategoryDetailPage.tsx
@@ -1,0 +1,21 @@
+import SideCategoryMenu from '@/pages/category/SideCategoryMenu'
+
+export default function CategoryDetailPage() {
+    return (
+      <div className="w-full mt-[80px]">
+        <div className="max-w-[1400px] mx-auto flex gap-[40px] py-[40px]">
+          {/* 사이드 메뉴 (고정) */}
+          <aside className="w-[200px] flex-shrink-0">
+            <SideCategoryMenu />
+          </aside>
+  
+          {/* 콘텐츠 영역 */}
+          <section className="flex-1 ml-[40px]">
+            {/* 이미지 카드, 타이틀 등 들어감 */}
+            <h2 className="text-[20px] font-semibold mb-[24px]">전체보기</h2>
+            {/* 카드 그리드 등 */}
+          </section>
+        </div>
+      </div>
+    )
+  }

--- a/src/pages/category/CategoryPage.tsx
+++ b/src/pages/category/CategoryPage.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import StudyCard from '@/common/StudyCard'
+import SideCategoryMenu from '@/pages/category/SideCategoryMenu'
+import defaultThumbnail from '@/assets/images/default-thumbnail.png'
+import { FiChevronLeft, FiChevronRight } from "react-icons/fi"
+
+const dummyData = [
+  {
+    imageUrl: defaultThumbnail,
+    title: 'Python 웹크롤링 데이터 분석반',
+    description: '파이썬으로 웹 데이터 수집부터 분석까지! BeautifulSoup, Selenium 사용법 배우고 실제 프로젝트 만들어봐요. 매주 실습 과제로 포트폴리오도 완성해요.',
+    memberCount: 4,
+    time: '월, 수 오후 8시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: 'React 클론코딩 프로젝트 스터디',
+    description: '넷플릭스, 인스타그램 같은 유명 서비스 클론코딩해봐요! 컴포넌트 설계부터 상태관리까지 실무 개발 경험 쌓으면서 취업 준비도 함께해요.',
+    memberCount: 5,
+    time: '토요일 오후 5시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '알고리즘 문제풀이 매일 챌린지',
+    description: '코테 준비하는 사람들 모여라! 백준, 프로그래머스 문제 매일 1개씩 풀고 서로 풀이 공유해요. 어려운 문제는 함께 토론하면서 실력 늘려봐요.',
+    memberCount: 5,
+    time: '수요일 오후 3시',
+  },
+]
+
+export default function CategoryPage() {
+  const [startIndex, setStartIndex] = useState(0)
+  const maxVisible = 3
+  const newStudyData = dummyData.concat(dummyData) // 최대 6개까지 보이게
+  const visibleNewStudies = newStudyData.slice(startIndex, startIndex + maxVisible)
+
+  const handleNext = () => {
+    if (startIndex + maxVisible < newStudyData.length) {
+      setStartIndex((prev) => prev + 1)
+    }
+  }
+
+  const handlePrev = () => {
+    if (startIndex > 0) {
+      setStartIndex((prev) => prev - 1)
+    }
+  }
+
+  return (
+    <div className="w-full mt-[80px]">
+      <div className="max-w-[1400px] mx-auto flex gap-[40px] py-[40px]">
+        <aside className="w-[200px] flex-shrink-0">
+          <SideCategoryMenu />
+        </aside>
+
+        <section className="flex-1 flex flex-col gap-[64px]">
+
+          {/* 주간 인기 스터디 */}
+          <div>
+            <h2 className="text-[20px] font-semibold mb-[24px]">주간 인기 STUDY</h2>
+            <div className="flex flex-wrap gap-x-[40px] gap-y-[40px]">
+              {dummyData.map((item, index) => (
+                <StudyCard
+                  key={`weekly-${index}`}
+                  imageUrl={item.imageUrl}
+                  title={item.title}
+                  description={item.description}
+                  memberCount={item.memberCount}
+                  time={item.time}
+                  variant="horizontal"
+                  thumbnailRatio="w-[360px] h-[200px]"
+                  className="w-[360px]"
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* 신규 스터디 */}
+          <div>
+            <div className="flex justify-between items-center mt-[80px] mb-[24px]">
+              <h2 className="text-[20px] font-semibold flex items-center">신규 STUDY</h2>
+              <div className="flex gap-[8px] items-center">
+                <button
+                  onClick={handlePrev}
+                  disabled={startIndex === 0}
+                  className={`flex items-center justify-center w-[32px] h-[32px] cursor-pointer transition-colors duration-200
+                    ${startIndex === 0 ? 'text-[#bdbdbd]' : 'text-[#8349FF]'}`}
+                >
+                  <FiChevronLeft className="w-[20px] h-[20px]" />
+                </button>
+                <button
+                  onClick={handleNext}
+                  disabled={startIndex + maxVisible >= newStudyData.length}
+                  className={`flex items-center justify-center w-[32px] h-[32px] cursor-pointer transition-colors duration-200
+                    ${startIndex + maxVisible >= newStudyData.length ? 'text-[#bdbdbd]' : 'text-[#8349FF]'}`}
+                >
+                  <FiChevronRight className="w-[20px] h-[20px]" />
+                </button>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-x-[40px] gap-y-[40px] transition-all duration-300">
+              {visibleNewStudies.map((item, index) => (
+                <StudyCard
+                  key={`new-${startIndex + index}`}
+                  imageUrl={item.imageUrl}
+                  title={item.title}
+                  description={item.description}
+                  memberCount={item.memberCount}
+                  time={item.time}
+                  variant="horizontal"
+                  thumbnailRatio="w-[360px] h-[200px]"
+                  className="w-[360px]"
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* 전체 STUDY */}
+          <div>
+            <h2 className="text-[20px] font-semibold mt-[80px] mb-[24px]">전체 STUDY</h2>
+            <div className="flex flex-wrap gap-x-[40px] gap-y-[40px]">
+              {dummyData.concat(dummyData).slice(0, 4).map((item, index) => (
+                <StudyCard
+                  key={`total-${index}`}
+                  imageUrl={item.imageUrl}
+                  title={item.title}
+                  description={item.description}
+                  memberCount={item.memberCount}
+                  time={item.time}
+                  variant="vertical"
+                  thumbnailRatio="w-[260px] h-[260px]"
+                  className="w-[260px]"
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/category/SideCategoryMenu.tsx
+++ b/src/pages/category/SideCategoryMenu.tsx
@@ -1,0 +1,46 @@
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
+
+const sideMenu = {
+  category: 'IT · 프로그래밍',
+  items: ['전체', '웹 개발', '게임 개발'],
+}
+
+export default function SideCategoryMenu() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { category } = useParams()
+
+  const handleClick = (item: string) => {
+    if (item === '전체') {
+      navigate(`/category/${encodeURIComponent(category || '')}`)
+    } else {
+      navigate(`/category/${encodeURIComponent(category || '')}/${encodeURIComponent(item)}`)
+    }
+  }
+
+  return (
+    <aside className="w-[200px] flex flex-col gap-[64px]">
+      <h2 className="text-[24px] font-semibold">{sideMenu.category}</h2>
+      <ul className="flex flex-col gap-[24px]">
+      {sideMenu.items.map((item) => {
+        const isActive =
+            item === '전체'
+            ? location.pathname === `/category/${encodeURIComponent(category || '')}`
+            : location.pathname === `/category/${encodeURIComponent(category || '')}/${encodeURIComponent(item)}`
+
+        return (
+            <li
+            key={item}
+            className={`cursor-pointer text-[18px] transition-colors duration-200 ${
+                isActive ? 'text-[#8349FF] font-semibold' : 'text-[#D1D1D1] hover:text-[#8349FF]'
+            }`}
+            onClick={() => handleClick(item)}
+            >
+            {item}
+            </li>
+        )
+        })}
+      </ul>
+    </aside>
+  )
+}


### PR DESCRIPTION
카테고리 페이지 레이아웃, 사이드 메뉴, 신규 스터디 슬라이드 구현

## ✅ PR 요약

- 관련 이슈 번호 : #67 
- 작업요약 : 카테고리 페이지 및 스터디 섹션 구조 구현. 슬라이드 기능 포함.

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 카테고리 페이지 및 메뉴 구성. 대분류/소분류 클릭 시 라우팅 처리
- 공통 StudyCard 컴포넌트 적용. 가로형 카드(360x200)로 주간/신규/전체 섹션 구성.
- 신규 STUDY 슬라이드 구현

## 📸 스크린샷 (선택)
<img width="3420" height="4350" alt="screencapture-localhost-5173-category-2025-08-02-00_35_46" src="https://github.com/user-attachments/assets/901b2840-fd52-4f51-b66b-05be0325dfa9" />

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
