### PR TITLE
✨ feat: 메인 페이지 UI 추가 구현 및 메인하단 8아이콘 탭 추가

### DIFF
--- a/src/common/ArrowNavigation.tsx
+++ b/src/common/ArrowNavigation.tsx
@@ -18,7 +18,7 @@ export default function ArrowNavigation({
       <button
         onClick={onPrev}
         disabled={isPrevDisabled}
-        className="flex items-center justify-center w-[32px] h-[32px] text-[#bdbdbd] disabled:opacity-30
+        className="flex items-center justify-center w-[32px] h-[32px] text-[#8349FF] disabled:opacity-30
           cursor-pointer"
       >
         <FiChevronLeft className="w-[20px] h-[20px]" />

--- a/src/components/Main/CategoryShortcutTabs.tsx
+++ b/src/components/Main/CategoryShortcutTabs.tsx
@@ -1,0 +1,41 @@
+import { useNavigate } from 'react-router-dom'
+import { PiMedal, PiTarget } from 'react-icons/pi'
+import { TbFocus2, TbBomb } from 'react-icons/tb'
+import { FaFireAlt, FaStar } from 'react-icons/fa'
+import { LuSunMedium, LuFilePen } from 'react-icons/lu'
+
+const tabs = [
+  { label: 'BEST', filter: 'best', icon: <PiMedal size={28} /> },
+  { label: '실시간 인기', filter: 'popular', icon: <FaFireAlt size={28} /> },
+  { label: '맞춤추천', filter: 'goal', icon: <FaStar size={28} /> },
+  { label: '주말집중', filter: 'weekend', icon: <TbFocus2 size={28} /> },
+  { label: '새벽챌린지', filter: 'dawn', icon: <LuSunMedium size={28} /> },
+  { label: '마감임박', filter: 'deadline', icon: <TbBomb size={28} /> },
+  { label: '목표달성', filter: 'goal', icon: <PiTarget size={28} /> },
+  { label: '초보스터디', filter: 'beginner', icon: <LuFilePen size={28} /> },
+]
+
+const CategoryShortcutTabs = () => {
+  const navigate = useNavigate()
+
+  return (
+    <section className="py-6 px-4">
+      <div className="max-w-[1400px] mx-auto mt-[72px] mb-[72px] flex gap-[32px] justify-center flex-wrap">
+        {tabs.map((tab) => (
+          <button
+            key={tab.filter}
+            onClick={() => navigate(`/studies?filter=${tab.filter}`)}
+            className="flex flex-col items-center gap-[8px] cursor-pointer"
+          >
+            <div className="w-[72px] h-[72px] rounded-[28px] bg-[#6B46C1] flex items-center justify-center text-white">
+              {tab.icon}
+            </div>
+            <span className="text-[16px]">{tab.label}</span>
+          </button>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default CategoryShortcutTabs

--- a/src/components/Main/MainBanner.tsx
+++ b/src/components/Main/MainBanner.tsx
@@ -72,7 +72,10 @@ const MainBanner = () => {
               <FiChevronRight />
             </button>
             <div />
-            <button onClick={() => setIsPlaying((prev) => !prev)} className="cursor-pointer">
+            <button
+              onClick={() => setIsPlaying((prev) => !prev)}
+              className="cursor-pointer"
+            >
               {isPlaying ? <BsPauseFill /> : <BsPlayFill />}
             </button>
           </div>

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -1,83 +1,152 @@
-
 import defaultThumbnail from '@/assets/images/default-thumbnail.png'
 
 export interface StudyCardData {
-    imageUrl: string
-    title: string
-    description: string
-    memberCount?: number
-    time?: string
-  }
-  
-  export const dummyData: StudyCardData[] = [
-    {
-      imageUrl: defaultThumbnail,
-      title: 'JavaScript 입문반',
-      description: '기초 문법부터 실전까지 배워요!',
-      memberCount: 10,
-      time: '월, 수 오후 8시',
-    },
-    {
-      imageUrl: defaultThumbnail,
-      title: '토익 고득점 목표 스터디',
-      description: '파트별 문제풀이 집중 트레이닝!',
-      memberCount: 8,
-      time: '화, 목 오후 9시',
-    },
-    {
-      imageUrl: defaultThumbnail,
-      title: 'React Native 실전 앱 만들기',
-      description: '실제 앱을 기획하고 배포까지!',
-      memberCount: 12,
-      time: '토요일 오후 3시',
-    },
-    {
-      imageUrl: defaultThumbnail,
-      title: 'ChatGPT 업무 자동화',
-      description: '프롬프트 설계부터 자동화까지 실습',
-      memberCount: 9,
-      time: '일요일 오전 11시',
-    },
-    {
-      imageUrl: defaultThumbnail,
-      title: 'SNS 마케팅 전략',
-      description: '브랜딩과 콘텐츠 운영법을 배워요',
-      memberCount: 7,
-      time: '수요일 오후 7시',
-    },
-    {
-      imageUrl: defaultThumbnail,
-      title: 'Flutter 앱 개발 입문',
-      description: '앱 제작 실습 중심 스터디',
-      memberCount: 6,
-      time: '화, 목 오후 8시',
-    },
-    {
-      imageUrl: defaultThumbnail,
-      title: '영어회화 매일 루틴',
-      description: '하루 10문장 말하기 연습',
-      memberCount: 11,
-      time: '매일 오전 9시',
-    },
-    {
-      imageUrl: defaultThumbnail,
-      title: '챕터북 독서 습관',
-      description: '함께 읽고 이야기 나누기',
-      memberCount: 10,
-      time: '월, 금 오후 6시',
-    },
-    {
-      imageUrl: defaultThumbnail,
-      title: 'Python 기초반',
-      description: '입문자를 위한 실습 중심 Python 스터디',
-      memberCount: 10,
-      time: '토요일 오전 10시',
-    },
-    {
-        imageUrl: defaultThumbnail,
-        title: 'Python 기초반',
-        description: '입문자를 위한 실습 중심 Python 스터디',
-        memberCount: 10,
-        time: '토요일 오전 10시',
-      }
-  ]
+  imageUrl: string
+  title: string
+  description: string
+  memberCount?: number
+  time?: string
+}
+
+export const dummyData: StudyCardData[] = [
+  {
+    imageUrl: defaultThumbnail,
+    title: 'JavaScript 입문반',
+    description: '기초 문법부터 실전까지 배워요!',
+    memberCount: 10,
+    time: '월, 수 오후 8시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '토익 고득점 목표 스터디',
+    description: '파트별 문제풀이 집중 트레이닝!',
+    memberCount: 8,
+    time: '화, 목 오후 9시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: 'React Native 실전 앱 만들기',
+    description: '실제 앱을 기획하고 배포까지!',
+    memberCount: 12,
+    time: '토요일 오후 3시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: 'ChatGPT 업무 자동화',
+    description: '프롬프트 설계부터 자동화까지 실습',
+    memberCount: 9,
+    time: '일요일 오전 11시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: 'SNS 마케팅 전략',
+    description: '브랜딩과 콘텐츠 운영법을 배워요',
+    memberCount: 7,
+    time: '수요일 오후 7시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: 'Flutter 앱 개발 입문',
+    description: '앱 제작 실습 중심 스터디',
+    memberCount: 6,
+    time: '화, 목 오후 8시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '영어회화 매일 루틴',
+    description: '하루 10문장 말하기 연습',
+    memberCount: 11,
+    time: '매일 오전 9시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '챕터북 독서 습관',
+    description: '함께 읽고 이야기 나누기',
+    memberCount: 10,
+    time: '월, 금 오후 6시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: 'Python 기초반',
+    description: '입문자를 위한 실습 중심 Python 스터디',
+    memberCount: 10,
+    time: '토요일 오전 10시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: 'Python 기초반',
+    description: '입문자를 위한 실습 중심 Python 스터디',
+    memberCount: 10,
+    time: '토요일 오전 10시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '아침 기상 루틴 만들기',
+    description: '꾸준한 기상 시간으로 하루를 여는 습관',
+    memberCount: 6,
+    time: '매일 오전 6시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '매일 독서 30분',
+    description: '매일 짧게라도 책 읽는 습관 만들기',
+    memberCount: 9,
+    time: '매일 오후 10시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '매일 영어단어 10개 외우기',
+    description: '단어장은 각자 준비, 매일 테스트!',
+    memberCount: 7,
+    time: '매일 오후 9시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '매일 블로그 글쓰기',
+    description: '기술, 일상 등 매일 1포스팅 도전',
+    memberCount: 8,
+    time: '매일 오후 11시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '하루 10분 명상 루틴',
+    description: '마음을 가다듬는 10분의 습관',
+    memberCount: 5,
+    time: '매일 오전 8시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '매일 1시간 코딩 연습',
+    description: '꾸준히 실력을 키워보는 코딩 습관',
+    memberCount: 10,
+    time: '매일 오후 8시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '운동 루틴 만들기',
+    description: '홈트, 헬스, 스트레칭 등 자유롭게 실천',
+    memberCount: 12,
+    time: '월~금 오전 7시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '매일 일기 쓰기',
+    description: '자신을 돌아보는 5분의 시간',
+    memberCount: 6,
+    time: '매일 밤 10시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '영어 뉴스 매일 듣기',
+    description: '하루 1개 뉴스 듣고 요약 공유',
+    memberCount: 7,
+    time: '매일 오전 7시',
+  },
+  {
+    imageUrl: defaultThumbnail,
+    title: '오늘의 감사 3가지',
+    description: '긍정적인 하루를 위한 감사 일기',
+    memberCount: 4,
+    time: '매일 밤 9시',
+  },
+]

--- a/src/pages/auth/MainPage.tsx
+++ b/src/pages/auth/MainPage.tsx
@@ -1,78 +1,163 @@
+import { useState } from 'react'
 import StudyCard from '@/common/StudyCard'
 import { dummyData } from '@/data/dummyData'
 import MainBanner from '@/components/Main/MainBanner'
+import CategoryShortcutTabs from '@/components/Main/CategoryShortcutTabs'
+import ArrowNavigation from '@/common/ArrowNavigation'
 
-const GuestMainPage = () => {
+const MainPage = () => {
+  // 슬라이드 인덱스 상태
+  const [hotIndex, setHotIndex] = useState(0)
+  const [newIndex, setNewIndex] = useState(0)
+  const [steadyIndex, setSteadyIndex] = useState(0)
+
+  // 보여질 카드 수
+  const HOT_VISIBLE = 3
+  const NEW_VISIBLE = 3
+  const STEADY_VISIBLE = 4
+
+  // 데이터
+  const hotData = dummyData.slice(0, 10)
+  const newData = dummyData.slice(0, 10)
+  const steadyData = dummyData.slice(0, 10)
+
+  // 인덱스 최대값 보정
+  const maxHotIndex = Math.max(0, hotData.length - HOT_VISIBLE)
+  const maxNewIndex = Math.max(0, newData.length - NEW_VISIBLE)
+  const maxSteadyIndex = Math.max(0, steadyData.length - STEADY_VISIBLE)
+
   return (
-  <>
-  <MainBanner />
-  {/* HOT STUDY */}
-  <section className="py-6 px-4">
-    <div className="max-w-[1400px] mx-auto">
-      <h2 className="text-xl font-semibold mb-4">오늘의 HOT STUDY 10</h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-[40px]">
-        {dummyData.slice(0, 3).map((item, index) => (
-          <StudyCard
-            key={index}
-            imageUrl={item.imageUrl}
-            title={item.title}
-            description={item.description}
-            memberCount={item.memberCount}
-            time={item.time}
-            variant="horizontal"
-            thumbnailRatio="w-[440px] h-[256px]"
-            className="w-[440px]"
-          />
-        ))}
-      </div>
-    </div>
-  </section>
+    <>
+      <MainBanner />
+      <CategoryShortcutTabs />
 
-  {/* NEW STUDY */}
-  <section className="py-6 px-4">
-    <div className="max-w-[1400px] mx-auto">
-      <h2 className="text-xl font-semibold mb-4">NEW STUDY</h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-[40px]">
-        {dummyData.slice(3, 6).map((item, index) => (
-          <StudyCard
-            key={index}
-            imageUrl={item.imageUrl}
-            title={item.title}
-            description={item.description}
-            memberCount={item.memberCount}
-            time={item.time}
-            variant="horizontal"
-            thumbnailRatio="w-[440px] h-[256px]"
-            className="w-[440px]"
-          />
-        ))}
-      </div>
-    </div>
-  </section>
+      {/* HOT STUDY */}
+      <section className="py-6 px-4">
+        <div className="max-w-[1400px] mx-auto mb-[88px]">
+          <div className="flex items-center justify-between mb-[32px]">
+            <h2 className="text-xl font-semibold">오늘의 HOT STUDY 10</h2>
+            <ArrowNavigation
+              onPrev={() => setHotIndex((prev) => Math.max(prev - 1, 0))}
+              onNext={() =>
+                setHotIndex((prev) => Math.min(prev + 1, maxHotIndex))
+              }
+              isPrevDisabled={hotIndex === 0}
+              isNextDisabled={hotIndex >= maxHotIndex}
+            />
+          </div>
 
-  {/* STEADY STUDY */}
-  <section className="py-6 px-4">
-    <div className="max-w-[1400px] mx-auto">
-      <h2 className="text-xl font-semibold mb-4">STEADY STUDY</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-[40px]">
-        {dummyData.slice(6, 10).map((item, index) => (
-          <StudyCard
-            key={index}
-            imageUrl={item.imageUrl}
-            title={item.title}
-            description={item.description}
-            memberCount={item.memberCount}
-            time={item.time}
-            variant="vertical"
-            thumbnailRatio="w-[320px] h-[320px]"
-            className="w-[320px]"
-          />
-        ))}
-      </div>
-    </div>
-  </section>
+          <div className="relative overflow-hidden">
+            <div
+              className="flex transition-transform duration-300 gap-[40px]"
+              style={{
+                transform: `translateX(-${hotIndex * (440 + 40)}px)`,
+                width: `${hotData.length * (440 + 40)}px`,
+              }}
+            >
+              {hotData.map((item, index) => (
+                <div key={`hot-${index}`} className="shrink-0 w-[440px]">
+                  <StudyCard
+                    imageUrl={item.imageUrl}
+                    title={item.title}
+                    description={item.description}
+                    memberCount={item.memberCount}
+                    time={item.time}
+                    variant="horizontal"
+                    thumbnailRatio="w-[440px] h-[256px]"
+                    className="w-[440px]"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* NEW STUDY */}
+      <section className="py-6 px-4">
+        <div className="max-w-[1400px] mx-auto mb-[88px]">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold">NEW STUDY</h2>
+            <ArrowNavigation
+              onPrev={() => setNewIndex((prev) => Math.max(prev - 1, 0))}
+              onNext={() =>
+                setNewIndex((prev) => Math.min(prev + 1, maxNewIndex))
+              }
+              isPrevDisabled={newIndex === 0}
+              isNextDisabled={newIndex >= maxNewIndex}
+            />
+          </div>
+
+          <div className="relative overflow-hidden">
+            <div
+              className="flex transition-transform duration-300 gap-[40px]"
+              style={{
+                transform: `translateX(-${newIndex * (440 + 40)}px)`,
+                width: `${newData.length * (440 + 40)}px`,
+              }}
+            >
+              {newData.map((item, index) => (
+                <div key={`new-${index}`} className="shrink-0 w-[440px]">
+                  <StudyCard
+                    imageUrl={item.imageUrl}
+                    title={item.title}
+                    description={item.description}
+                    memberCount={item.memberCount}
+                    time={item.time}
+                    variant="horizontal"
+                    thumbnailRatio="w-[440px] h-[256px]"
+                    className="w-[440px]"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* STEADY STUDY */}
+      <section className="py-6 px-4">
+        <div className="max-w-[1400px] mx-auto mb-[120px]">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold">STEADY STUDY</h2>
+            <ArrowNavigation
+              onPrev={() => setSteadyIndex((prev) => Math.max(prev - 1, 0))}
+              onNext={() =>
+                setSteadyIndex((prev) => Math.min(prev + 1, maxSteadyIndex))
+              }
+              isPrevDisabled={steadyIndex === 0}
+              isNextDisabled={steadyIndex >= maxSteadyIndex}
+            />
+          </div>
+
+          <div className="relative overflow-hidden">
+            <div
+              className="flex transition-transform duration-300 gap-[40px]"
+              style={{
+                transform: `translateX(-${steadyIndex * (320 + 40)}px)`,
+                width: `${steadyData.length * (320 + 40)}px`,
+              }}
+            >
+              {steadyData.map((item, index) => (
+                <div key={`steady-${index}`} className="shrink-0 w-[320px]">
+                  <StudyCard
+                    imageUrl={item.imageUrl}
+                    title={item.title}
+                    description={item.description}
+                    memberCount={item.memberCount}
+                    time={item.time}
+                    variant="vertical"
+                    thumbnailRatio="w-[320px] h-[320px]"
+                    className="w-[320px]"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
     </>
   )
 }
 
-export default GuestMainPage
+export default MainPage

--- a/src/pages/category/CategoryPage.tsx
+++ b/src/pages/category/CategoryPage.tsx
@@ -66,7 +66,7 @@ export default function CategoryPage() {
           {/* 주간 인기 스터디 */}
           <div>
             <h2 className="text-[20px] font-semibold mb-[24px]">
-              주간 인기 STUDY
+              주간 인기 STUDY 3
             </h2>
             <div className="flex flex-wrap gap-x-[40px] gap-y-[40px]">
               {dummyData.map((item, index) => (


### PR DESCRIPTION
feat: 메인 페이지 UI 추가 구현 및 메인하단 8아이콘 탭 추가

## ✅ PR 요약

- 관련 이슈 번호 : #81 
- 작업요약 : 메인 페이지 UI 추가 구현 및 메인하단 8아이콘 탭 추가

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 메인 이미지 하단 8아이콘 탭 추가
- STEADY STUDY 화살표 클릭 비활성화 에러 더미데이터 추가로 해결
- HOT STUDY, NEW STUDY, STEADY STUDY 애니메이션 추가

## 📸 스크린샷 (선택)
<img width="3420" height="6162" alt="screencapture-localhost-5173-2025-08-07-11_34_40" src="https://github.com/user-attachments/assets/f2b41bed-77a1-41d0-bf4a-006c006aca31" />


## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
