### PR TITLE
✨ feat: 메인 페이지에 참여 중인 스터디 섹션 조건부 렌더링 추가

### DIFF
--- a/src/components/Main/JoinedStudySection.tsx
+++ b/src/components/Main/JoinedStudySection.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import StudyCard from '@/common/StudyCard'
+import ArrowNavigation from '@/common/ArrowNavigation'
+import CommonButton from '@/common/CommonButton'
+
+interface StudyCardData {
+  imageUrl: string
+  title: string
+  description: string
+  memberCount?: number
+  time: string
+}
+
+interface JoinedStudySectionProps {
+  nickname: string
+  studies: StudyCardData[]
+}
+
+const JoinedStudySection = ({ nickname, studies }: JoinedStudySectionProps) => {
+  const [index, setIndex] = useState(0)
+  const VISIBLE = 3
+  const CARD_WIDTH = 440
+  const GAP = 40
+  const maxIndex = studies.length - VISIBLE
+
+  if (studies.length === 0) return null
+
+  return (
+    <section className="py-6 px-4">
+      <div className="max-w-[1400px] mx-auto mb-[88px]">
+        <div className="flex items-center justify-between mb-[32px]">
+          <h2 className="text-xl font-semibold">{nickname}님의 스터디</h2>
+          <ArrowNavigation
+            onPrev={() => setIndex((prev) => Math.max(prev - 1, 0))}
+            onNext={() => setIndex((prev) => Math.min(prev + 1, maxIndex))}
+            isPrevDisabled={index === 0}
+            isNextDisabled={index >= maxIndex}
+          />
+        </div>
+
+        <div className="relative overflow-hidden">
+          <div
+            className="flex transition-transform duration-300 gap-[40px]"
+            style={{
+              transform: `translateX(-${index * (CARD_WIDTH + GAP)}px)`,
+              width: `${studies.length * (CARD_WIDTH + GAP)}px`,
+            }}
+          >
+            {studies.map((item, i) => (
+              <div
+                key={`joined-${i}`}
+                className="shrink-0 w-[440px] flex flex-col gap-2"
+              >
+                <StudyCard
+                  imageUrl={item.imageUrl}
+                  title={item.title}
+                  description={item.description}
+                  memberCount={item.memberCount}
+                  time={item.time}
+                  variant="horizontal"
+                  thumbnailRatio="w-[440px] h-[256px]"
+                  className="w-[440px]"
+                />
+                <CommonButton
+                  variant="primary"
+                  visualScale="md"
+                  onClick={() => alert(`${item.title} 스터디 페이지로 이동`)}
+                >
+                  스터디 참여
+                </CommonButton>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default JoinedStudySection

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -1,11 +1,11 @@
 import defaultThumbnail from '@/assets/images/default-thumbnail.png'
 
-export interface StudyCardData {
+export type StudyCardData = {
   imageUrl: string
   title: string
   description: string
   memberCount?: number
-  time?: string
+  time: string
 }
 
 export const dummyData: StudyCardData[] = [

--- a/src/pages/auth/MainPage.tsx
+++ b/src/pages/auth/MainPage.tsx
@@ -4,6 +4,9 @@ import { dummyData } from '@/data/dummyData'
 import MainBanner from '@/components/Main/MainBanner'
 import CategoryShortcutTabs from '@/components/Main/CategoryShortcutTabs'
 import ArrowNavigation from '@/common/ArrowNavigation'
+import JoinedStudySection from '@/components/Main/JoinedStudySection'
+
+const isLoggedIn = false // 추후 로그인 구현 시 교체 예정
 
 const MainPage = () => {
   // 슬라이드 인덱스 상태
@@ -26,10 +29,21 @@ const MainPage = () => {
   const maxNewIndex = Math.max(0, newData.length - NEW_VISIBLE)
   const maxSteadyIndex = Math.max(0, steadyData.length - STEADY_VISIBLE)
 
+  const user = {
+    nickname: '뭉치면주먹밥',
+    joinedStudies: dummyData.slice(0, 6),
+  }
+
   return (
     <>
       <MainBanner />
       <CategoryShortcutTabs />
+      {isLoggedIn && (
+        <JoinedStudySection
+          nickname={user.nickname}
+          studies={user.joinedStudies}
+        />
+      )}
 
       {/* HOT STUDY */}
       <section className="py-6 px-4">


### PR DESCRIPTION
메인 페이지 참여 스터디 섹션 구현 및 조건부 렌더링 적용

## ✅ PR 요약

- 관련 이슈 번호 : #102 
- 작업요약 : 어떤 작업을 했는지 간단하게 적어주세요

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- `JoinedStudySection` 컴포넌트 구현: 참여 중인 스터디 카드 슬라이드로 구성
- `MainPage.tsx`에 `JoinedStudySection` 컴포넌트 렌더링 추가
- `isLoggedIn` 변수 도입으로 로그인 여부에 따라 해당 섹션 조건부 렌더링 처리
- 전역 상태나 API 연동 없이 테스트 가능한 구조로 임시 구현

## 📸 스크린샷 (선택)

<img width="3420" height="6162" alt="screencapture-localhost-5173-2025-08-07-14_54_18" src="https://github.com/user-attachments/assets/750516e5-5e54-422c-83fa-74f1ac6df67f" />


## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
