### PR TITLE
✨ feat: 회원 가입 페이지 msw API 모킹 적용

### DIFF
--- a/src/api/mswMock/MockData.ts
+++ b/src/api/mswMock/MockData.ts
@@ -14,7 +14,7 @@ export const mockUsers: MockData[] = [
     email: 'yongar@example.com',
     password: '1234',
     user_id: 1,
-    nickname: 'oz_user1',
+    nickname: 'ozuser1',
     name: '김오즈',
     phone: '01012345678',
     birthday: '1990-01-25',

--- a/src/api/mswMock/MockData.ts
+++ b/src/api/mswMock/MockData.ts
@@ -1,4 +1,15 @@
-export const mockUsers = [
+interface MockData {
+  email: string
+  password: string
+  user_id: number
+  nickname: string
+  name: string
+  phone: string
+  birthday: string
+  profile_image_url: string | null
+}
+
+export const mockUsers: MockData[] = [
   {
     email: 'yongar@example.com',
     password: '1234',

--- a/src/api/mswMock/handlers.ts
+++ b/src/api/mswMock/handlers.ts
@@ -119,4 +119,23 @@ export const handlers = [
       { status: 201 }
     )
   }),
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////// 닉네임 중복확인
+
+  http.post('/api/v1/users/nickname/duplication', async ({ request }) => {
+    const { nickname } = await request.clone().json()
+
+    const nicknameExists = mockUsers.some((user) => user.nickname === nickname)
+
+    if (nicknameExists) {
+      return HttpResponse.json(
+        { detail: '이미 사용 중인 닉네임입니다' },
+        { status: 409 }
+      )
+    }
+
+    return HttpResponse.json(
+      { detail: '사용 가능한 닉네임입니다' },
+      { status: 200 }
+    )
+  }),
 ]

--- a/src/api/mswMock/handlers.ts
+++ b/src/api/mswMock/handlers.ts
@@ -5,6 +5,8 @@ import type { SignupForm } from '@/types/signupForm'
 const MOCK_ACCESS_TOKEN = 'abcdefg1234' //테스트용 토큰
 const MOCK_REFRESH_TOKEN = 'aabbcddwecqw123'
 
+const verificationCodes = new Map<string, string>() // 휴대폰 6자리 인증번호 저장용
+
 export const handlers = [
   //////////////////////////////////////////////////////////////////////////////////////////////////////////// 로그인
   http.post(`/api/v1/auth/login/`, async ({ request }) => {
@@ -137,5 +139,49 @@ export const handlers = [
       { detail: '사용 가능한 닉네임입니다' },
       { status: 200 }
     )
+  }),
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////// 휴대폰 인증번호 전송
+
+  http.post('/api/v1/auth/send-code', async ({ request }) => {
+    const { phoneNumber } = await request.clone().json()
+
+    if (!phoneNumber) {
+      return HttpResponse.json(
+        { detail: '휴대폰 번호는 필수입니다.' },
+        { status: 400 }
+      )
+    }
+    const generateCode = () =>
+      Math.floor(100000 + Math.random() * 900000).toString()
+    const code = generateCode()
+    verificationCodes.set(phoneNumber, code)
+
+    return HttpResponse.json(
+      { detail: `휴대폰 인증번호는 [${code}] 입니다.` },
+      { status: 200 }
+    )
+  }),
+  http.post('/api/v1/auth/verify-code', async ({ request }) => {
+    const { phoneNumber, code }: { phoneNumber: string; code: string } =
+      await request.clone().json()
+
+    if (!phoneNumber || !code) {
+      return HttpResponse.json(
+        { detail: '휴대폰 번호와 인증번호는 필수입니다.' },
+        { status: 400 }
+      )
+    }
+
+    const storedCode = verificationCodes.get(phoneNumber)
+
+    if (storedCode === code) {
+      verificationCodes.delete(phoneNumber) // 일회용
+      return HttpResponse.json({ detail: '인증 성공' }, { status: 200 })
+    } else {
+      return HttpResponse.json(
+        { detail: '인증번호가 일치하지 않습니다.' },
+        { status: 400 }
+      )
+    }
   }),
 ]

--- a/src/api/mswMock/handlers.ts
+++ b/src/api/mswMock/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw'
 import { mockUsers } from '@/api/mswMock/MockData'
+import type { SignupForm } from '@/types/signupForm'
 
 const MOCK_ACCESS_TOKEN = 'abcdefg1234' //테스트용 토큰
 const MOCK_REFRESH_TOKEN = 'aabbcddwecqw123'
@@ -7,8 +8,6 @@ const MOCK_REFRESH_TOKEN = 'aabbcddwecqw123'
 export const handlers = [
   //////////////////////////////////////////////////////////////////////////////////////////////////////////// 로그인
   http.post(`/api/v1/auth/login/`, async ({ request }) => {
-    // const data = await request.clone().json();
-    // console.log(data);
     const { email, password } = await request.clone().json()
 
     const matchedUserEmail = mockUsers.find((user) => user.email === email)
@@ -41,8 +40,83 @@ export const handlers = [
   }),
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////// 로그아웃
   http.post('/api/v1/auth/logout', async () => {
-    // const data = request
-    // console.log(data);
     return HttpResponse.json({ status: 200 })
+  }),
+
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////// 회원가입
+  http.post('/api/v1/users/signup/', async ({ request }) => {
+    const {
+      fullname,
+      email,
+      nickname,
+      phone_number,
+      password,
+      gender,
+    }: SignupForm = await request.clone().json()
+
+    if (
+      !fullname ||
+      !email ||
+      !nickname ||
+      !phone_number ||
+      !password ||
+      !gender
+    ) {
+      return HttpResponse.json(
+        { detail: '모든 필수 항목을 입력해야 합니다.' },
+        { status: 400 }
+      )
+    }
+    const nicknameExists = mockUsers.some((user) => user.nickname === nickname)
+    if (nicknameExists) {
+      return HttpResponse.json(
+        { detail: '이미 사용 중인 닉네임입니다.' },
+        { status: 400 }
+      )
+    }
+
+    const emailExists = mockUsers.some((user) => user.email === email)
+
+    const phoneExists = mockUsers.some((user) => user.phone === phone_number)
+
+    if (emailExists) {
+      return HttpResponse.json(
+        { detail: '이미 등록된 이메일 입니다.' },
+        { status: 409 }
+      )
+    }
+
+    if (phoneExists) {
+      return HttpResponse.json(
+        { detail: '이미 등록된 전화번호입니다.' },
+        { status: 409 }
+      )
+    }
+
+    const phoneRegex = /^\d+$/
+    if (!phoneRegex.test(phone_number)) {
+      return HttpResponse.json(
+        { detail: '휴대폰 번호 형식이 올바르지 않습니다.' },
+        { status: 422 }
+      )
+    }
+
+    const newUser = {
+      user_id: mockUsers.length + 1,
+      email,
+      password,
+      nickname,
+      name: fullname,
+      phone: phone_number,
+      birthday: '1990-01-01',
+      profile_image_url: null,
+    }
+
+    mockUsers.push(newUser)
+
+    return HttpResponse.json(
+      { message: '회원가입이 완료되었습니다.' },
+      { status: 201 }
+    )
   }),
 ]

--- a/src/common/InputField.tsx
+++ b/src/common/InputField.tsx
@@ -53,7 +53,7 @@ export default function InputField({
         <p className="text-xs text-alertText font-medium mt-1">* {error}</p>
       )}
       {!error && success && (
-        <p className="text-xs text-alertText font-medium mt-1">* {success}</p>
+        <p className="text-xs text-green-500 font-medium mt-1">* {success}</p>
       )}
     </div>
   )

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -5,9 +5,16 @@ import type { SignupForm } from '@/types/signupForm'
 import { useForm, Controller } from 'react-hook-form'
 import { joiResolver } from '@hookform/resolvers/joi'
 import signupFormSchema from '@/schemas/signupFormSchema'
+import { api } from '@/api/mainApi'
+import type { AxiosError } from 'axios'
+import { useState } from 'react'
+import type { ErrorMessage } from '@/types/errorMessage'
 
 export default function SignupPage() {
   const navigate = useNavigate()
+  const [apiErrorMessage, setApiErrorMessage] = useState<ErrorMessage | null>(
+    null
+  )
 
   const {
     control,
@@ -16,20 +23,31 @@ export default function SignupPage() {
   } = useForm<SignupForm>({
     resolver: joiResolver(signupFormSchema), // Joi를 React Hook Form과 연결
     defaultValues: {
-      name: '',
+      fullname: '',
       email: '',
       nickname: '',
-      phone: '',
+      phone_number: '',
       password: '',
       gender: '남', // 또는 '남'/'여' 중 기본값
     },
     mode: 'onChange', // 입력값이 변경될 때마다 유효성 검사
   })
 
-  const onSubmit = (_data: SignupForm) => {
-    // console.log('Form Data:', data)
-    // 여기에 회원가입 로직을 추가하세요
-    navigate('/auth/signup/terms') // 회원가입 성공 페이지로 이동
+  const onSubmit = async (data: SignupForm) => {
+    try {
+      const res = await api.post('/api/v1/users/signup/', data)
+      if (res.status === 201) {
+        navigate('/auth/signup/terms') // 회원가입 성공 페이지 이동
+      }
+    } catch (error) {
+      const axiosError = error as AxiosError<{ detail: string }>
+      if (!axiosError.status) return
+      setApiErrorMessage({
+        status: axiosError.status,
+        message:
+          axiosError.response?.data.detail ?? '알 수 없는 오류가 발생했습니다.',
+      })
+    }
   }
 
   return (
@@ -44,7 +62,7 @@ export default function SignupPage() {
         >
           <div className="flex flex-col pace-y-3 gap-[16px]">
             <Controller
-              name="name"
+              name="fullname"
               control={control}
               rules={{ required: '이름은 필수입니다' }}
               render={({ field, fieldState }) => (
@@ -96,7 +114,7 @@ export default function SignupPage() {
             </div>
             <div className="flex w-full gap-[4px]">
               <Controller
-                name="phone"
+                name="phone_number"
                 control={control}
                 rules={{ required: '휴대전화는 필수입니다' }}
                 render={({ field, fieldState }) => (
@@ -160,7 +178,7 @@ export default function SignupPage() {
               />
             </div>
           </div>
-          <div className="flex flex-col justify-center items-center gap-[24px] w-full">
+          <div className="flex flex-col gap-1.5 w-full">
             <CommonButton
               variant="disabled"
               disabled={!isValid}
@@ -168,6 +186,11 @@ export default function SignupPage() {
             >
               다음
             </CommonButton>
+            {apiErrorMessage && (
+              <p className="text-xs text-alertText font-medium mt-1">
+                * {apiErrorMessage.message}
+              </p>
+            )}
           </div>
         </form>
       </div>

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -15,9 +15,12 @@ export default function SignupPage() {
   const [apiErrorMessage, setApiErrorMessage] = useState<ErrorMessage | null>(
     null
   )
+  const [nicknameCheckMessage, setNicknameCheckMessage] =
+    useState<ErrorMessage | null>(null)
 
   const {
     control,
+    getValues,
     handleSubmit,
     formState: { isValid },
   } = useForm<SignupForm>({
@@ -32,6 +35,29 @@ export default function SignupPage() {
     },
     mode: 'onChange', // 입력값이 변경될 때마다 유효성 검사
   })
+
+  const handleDuplicateNicknameCheck = async () => {
+    try {
+      const nickname = getValues('nickname')
+      const res = await api.post('/api/v1/users/nickname/duplication', {
+        nickname,
+      })
+      if (res.status === 200) {
+        setNicknameCheckMessage({
+          status: res.status,
+          message: res.data.detail,
+        })
+      }
+    } catch (error) {
+      const axiosError = error as AxiosError<{ detail: string }>
+      if (!axiosError.status) return
+      setNicknameCheckMessage({
+        status: axiosError.status,
+        message:
+          axiosError.response?.data.detail ?? '알 수 없는 오류가 발생했습니다.',
+      })
+    }
+  }
 
   const onSubmit = async (data: SignupForm) => {
     try {
@@ -100,7 +126,16 @@ export default function SignupPage() {
                     className="w-[224px] h-[48px] placeholder:text-text4"
                     placeholder="닉네임"
                     type="text"
-                    error={fieldState.error?.message}
+                    error={
+                      nicknameCheckMessage?.status === 409
+                        ? nicknameCheckMessage?.message
+                        : fieldState.error?.message
+                    }
+                    success={
+                      nicknameCheckMessage?.status === 200
+                        ? nicknameCheckMessage?.message
+                        : undefined
+                    }
                   />
                 )}
               />
@@ -108,6 +143,7 @@ export default function SignupPage() {
                 type="button"
                 variant="grayStyle"
                 className="w-full text-[16px]"
+                onClick={handleDuplicateNicknameCheck}
               >
                 중복확인
               </CommonButton>

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -9,14 +9,24 @@ import { api } from '@/api/mainApi'
 import type { AxiosError } from 'axios'
 import { useState } from 'react'
 import type { ErrorMessage } from '@/types/errorMessage'
+import { cn } from '@/utils/cn'
 
 export default function SignupPage() {
   const navigate = useNavigate()
-  const [apiErrorMessage, setApiErrorMessage] = useState<ErrorMessage | null>(
-    null
-  )
+  const [submitErrorMessage, setSubmitErrorMessage] =
+    useState<ErrorMessage | null>(null)
   const [nicknameCheckMessage, setNicknameCheckMessage] =
     useState<ErrorMessage | null>(null)
+
+  const [codeCheckMessage, setCodeCheckMessage] = useState<ErrorMessage | null>(
+    null
+  )
+  const [receivedAuthCode, setReceivedAuthCode] = useState<ErrorMessage | null>(
+    null
+  )
+  const [enteredAuthCode, setEnteredAuthCode] = useState<string>('')
+  const [isAvailableNickname, setIsAvailableNickname] = useState(false)
+  const [isCodeVerified, setIsCodeVerified] = useState(false)
 
   const {
     control,
@@ -47,6 +57,8 @@ export default function SignupPage() {
           status: res.status,
           message: res.data.detail,
         })
+        setIsAvailableNickname(true)
+        return
       }
     } catch (error) {
       const axiosError = error as AxiosError<{ detail: string }>
@@ -64,11 +76,12 @@ export default function SignupPage() {
       const res = await api.post('/api/v1/users/signup/', data)
       if (res.status === 201) {
         navigate('/auth/signup/terms') // 회원가입 성공 페이지 이동
+        return
       }
     } catch (error) {
       const axiosError = error as AxiosError<{ detail: string }>
       if (!axiosError.status) return
-      setApiErrorMessage({
+      setSubmitErrorMessage({
         status: axiosError.status,
         message:
           axiosError.response?.data.detail ?? '알 수 없는 오류가 발생했습니다.',
@@ -76,11 +89,51 @@ export default function SignupPage() {
     }
   }
 
+  const requestPhoneAuthCode = async () => {
+    const phoneNumber = getValues('phone_number')
+    try {
+      const res = await api.post('/api/v1/auth/send-code', { phoneNumber })
+      if (res.status === 200) {
+        setReceivedAuthCode({ status: res.status, message: res.data.detail })
+        return
+      }
+    } catch (error) {
+      const axiosError = error as AxiosError<{ detail: string }>
+      if (!axiosError.status) return
+      setReceivedAuthCode(null)
+    }
+  }
+
+  const phoneAuthCodeverify = async () => {
+    const phoneNumber = getValues('phone_number')
+    try {
+      const res = await api.post('/api/v1/auth/verify-code', {
+        phoneNumber,
+        code: enteredAuthCode,
+      })
+      if (res.status === 200) {
+        setIsCodeVerified(true)
+        setCodeCheckMessage({ status: res.status, message: res.data.detail })
+        return
+      }
+      setIsCodeVerified(false)
+    } catch (error) {
+      const axiosError = error as AxiosError<{ detail: string }>
+      if (!axiosError.status) return
+      setCodeCheckMessage({
+        status: axiosError.status,
+        message:
+          axiosError.response?.data.detail ?? '알 수 없는 오류가 발생했습니다.',
+      })
+      setIsCodeVerified(false)
+    }
+  }
+
   return (
     <div className="flex flex-col items-center justify-center bg-white h-[856px]">
       <div className="flex flex-col items-center justify-center gap-[56px] w-[344px]">
         <div className="flex flex-col items-center justify-center gap-[24px]">
-          <div className="text-[32px] font-semibold">계정찾기</div>
+          <div className="text-[32px] font-semibold">회원가입</div>
         </div>
         <form
           onSubmit={handleSubmit(onSubmit)}
@@ -160,17 +213,54 @@ export default function SignupPage() {
                     placeholder="휴대전화"
                     type="number"
                     error={fieldState.error?.message}
+                    success={receivedAuthCode?.message}
                   />
                 )}
               />
               <CommonButton
                 type="button"
-                variant="grayStyle"
-                className="w-full text-[16px]"
+                variant={receivedAuthCode ? 'secondary' : 'grayStyle'}
+                className={cn(
+                  'w-full text-[16px]',
+                  receivedAuthCode ? 'border border-primary' : ''
+                )}
+                onClick={requestPhoneAuthCode}
               >
-                인증번호전송
+                {receivedAuthCode ? '재전송' : '인증번호전송'}
               </CommonButton>
             </div>
+            {receivedAuthCode && (
+              <div className="flex w-full gap-[4px]">
+                <InputField
+                  className="w-[224px] h-[48px] placeholder:text-text4"
+                  value={enteredAuthCode}
+                  onChange={(e) => setEnteredAuthCode(e.target.value)}
+                  error={
+                    codeCheckMessage?.status !== 200
+                      ? codeCheckMessage?.message
+                      : undefined
+                  }
+                  success={
+                    codeCheckMessage?.status === 200
+                      ? codeCheckMessage?.message
+                      : undefined
+                  }
+                />
+                <CommonButton
+                  type="button"
+                  variant="grayStyle"
+                  disabled={!/^\d{6}$/.test(enteredAuthCode)}
+                  className={cn(
+                    'w-full text-[16px]',
+                    /^\d{6}$/.test(enteredAuthCode) &&
+                      'bg-secondary text-primary border border-primary hover:bg-secondary-hover '
+                  )}
+                  onClick={phoneAuthCodeverify}
+                >
+                  인증번호확인
+                </CommonButton>
+              </div>
+            )}
             <Controller
               name="password"
               control={control}
@@ -217,14 +307,14 @@ export default function SignupPage() {
           <div className="flex flex-col gap-1.5 w-full">
             <CommonButton
               variant="disabled"
-              disabled={!isValid}
-              className={`text-[15px] w-full ${isValid ? 'cursor-pointer bg-primary text-text3 hover:bg-primary-hover' : ''}  `}
+              disabled={!isValid || !isAvailableNickname || !isCodeVerified}
+              className={`text-[15px] w-full ${isValid && isAvailableNickname && isCodeVerified ? 'cursor-pointer bg-primary text-text3 hover:bg-primary-hover' : ''}  `}
             >
               다음
             </CommonButton>
-            {apiErrorMessage && (
+            {submitErrorMessage && (
               <p className="text-xs text-alertText font-medium mt-1">
-                * {apiErrorMessage.message}
+                * {submitErrorMessage.message}
               </p>
             )}
           </div>

--- a/src/pages/auth/loginPage.tsx
+++ b/src/pages/auth/loginPage.tsx
@@ -7,11 +7,7 @@ import type { UserDataWithToken } from '@/types/userData'
 import { api } from '@/api/mainApi'
 import { useUserInfo } from '@/store/userInfoStore'
 import type { AxiosError } from 'axios'
-
-interface ErrorMessage {
-  status: number
-  message: string
-}
+import type { ErrorMessage } from '@/types/errorMessage'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -80,6 +76,7 @@ export default function LoginPage() {
               className="w-full h-12 placeholder:text-text4"
               placeholder="비밀번호(6~15자의 영문 대소문자, 숫자, 특수문자 포함)"
               value={password}
+              type="password"
               onChange={(e) => setPassword(e.target.value)}
               error={
                 errorMessage?.status === 401 ? errorMessage?.message : undefined

--- a/src/schemas/signupFormSchema.ts
+++ b/src/schemas/signupFormSchema.ts
@@ -1,7 +1,7 @@
 import Joi from 'joi'
 
 const signupFormSchema = Joi.object({
-  name: Joi.string().required().messages({
+  fullname: Joi.string().required().messages({
     'string.empty': '이름을 입력해주세요.',
   }),
 
@@ -21,7 +21,7 @@ const signupFormSchema = Joi.object({
       'string.pattern.base': '닉네임은 특수문자를 포함할 수 없습니다.',
     }),
 
-  phone: Joi.string().pattern(/^\d+$/).required().messages({
+  phone_number: Joi.string().pattern(/^\d+$/).required().messages({
     'string.empty': '휴대전화를 입력해주세요.',
     'string.pattern.base': '휴대전화는 숫자만 입력 가능합니다.',
   }),

--- a/src/types/errorMessage.ts
+++ b/src/types/errorMessage.ts
@@ -1,0 +1,4 @@
+export interface ErrorMessage {
+  status: number
+  message: string
+}

--- a/src/types/signupForm.ts
+++ b/src/types/signupForm.ts
@@ -1,8 +1,8 @@
 export interface SignupForm {
-  name: string
+  fullname: string
   email: string
   nickname: string
-  phone: string
+  phone_number: string
   password: string
   gender: '남' | '여'
 }


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #101 
- 작업요약 : 회원가입 페이지 msw API 모킹 연경

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 닉네임 중복 확인 , 휴대폰 인증번호 받기/확인하기 msw API 구현
- 닉네임 중복 , 휴대폰 인증 완료 후 회원 가입 양식에 맞게 작성 시 제출 가능
- 회원가입,닉네임, 인증번호 예외저리 적용 및 안내 메시지 표현
- msw 로 휴대폰으로 인증번호를 받을 수 없어 개발 과정에서 화면에 인증번호를 표시 

## 📸 스크린샷 (선택)

►닉네임 중복확인 및 인증번호 받기
<img width="300" alt="CleanShot 2025-08-07 at 20 04 43@2x" src="https://github.com/user-attachments/assets/2275ef7c-4fed-43af-9fb8-2e5a7d81582e" />

<br/>
<br/>
<br/>

►닉네임 중복, 휴대폰 인증완료 후 양식에 맞게 작성 시 제출 가능
<img width="300"  alt="CleanShot 2025-08-07 at 20 06 16@2x" src="https://github.com/user-attachments/assets/c4999282-1aa1-42fd-8c56-890b65e27da0" />


<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
