### PR TITLE
✨ feat: 검색 결과 페이지 구현 및 SearchResultList 컴포넌트 분리

### DIFF
--- a/src/components/Layout/CategoryMenu.tsx
+++ b/src/components/Layout/CategoryMenu.tsx
@@ -1,26 +1,10 @@
 import { useNavigate } from 'react-router-dom'
-
-interface CategoryItem {
-  title: string
-  items: string[]
-}
+import { categoryData, toPath } from '@/data/categoryData'
 
 interface CategoryMenuProps {
   onCategorySelect?: (category: string, item: string) => void
   onClose?: () => void
 }
-
-const categoryData: CategoryItem[] = [
-  { title: '언어', items: ['영어', '일본어'] },
-  { title: '자격증', items: ['전산/세무/회계', '컴퓨터활용능력'] },
-  { title: '디자인', items: ['포토샵/일러스트', '피그마'] },
-  { title: 'IT·프로그래밍', items: ['웹 개발', '게임 개발'] },
-  { title: '경영·마케팅', items: ['경영전략', '마케팅'] },
-  { title: '취미', items: ['영화', '독서'] },
-]
-
-// 한글/공백 안전 경로 변환
-const toPath = (s: string) => encodeURIComponent(s.replace(/\s+/g, '-'))
 
 export default function CategoryMenu({
   onCategorySelect,

--- a/src/components/search/SearchEmptyState.tsx
+++ b/src/components/search/SearchEmptyState.tsx
@@ -1,0 +1,10 @@
+export default function SearchEmptyState() {
+  return (
+    <div className="py-[140px] text-center text-[#C7C7C7]">
+      <p className="text-[28px] mb-[56px]">
+        검색 결과가 없어요. <br />
+        다른 키워드로 검색해보시거나 카테고리에서 찾아보세요!
+      </p>
+    </div>
+  )
+}

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -1,0 +1,35 @@
+import StudyCard from '@/common/StudyCard'
+
+interface Item {
+  imageUrl: string
+  title: string
+  description: string
+  memberCount?: number
+  time?: string
+}
+
+interface Props {
+  items: Item[]
+  onClickItem?: (item: Item) => void
+}
+
+export default function SearchResultList({ items, onClickItem }: Props) {
+  return (
+    <div className="grid grid-cols-3 gap-[40px]">
+      {items.map((item, i) => (
+        <StudyCard
+          key={`${item.title}-${i}`}
+          variant="horizontal"
+          className="w-[440px]"
+          thumbnailRatio="w-[440px] h-[256px]"
+          imageUrl={item.imageUrl}
+          title={item.title}
+          description={item.description}
+          memberCount={item.memberCount}
+          time={item.time}
+          onClick={() => onClickItem?.(item)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/data/categoryData.ts
+++ b/src/data/categoryData.ts
@@ -1,0 +1,18 @@
+export interface CategoryItem {
+  title: string
+  items: string[]
+}
+
+export const categoryData: CategoryItem[] = [
+  { title: '언어', items: ['영어', '일본어'] },
+  { title: '자격증', items: ['전산/세무/회계', '컴퓨터활용능력'] },
+  { title: '디자인', items: ['포토샵/일러스트', '피그마'] },
+  { title: 'IT·프로그래밍', items: ['웹 개발', '게임 개발'] },
+  { title: '경영·마케팅', items: ['경영전략', '마케팅'] },
+  { title: '취미', items: ['영화', '독서'] },
+]
+
+// URL 변환 헬퍼
+export const toPath = (s: string) => encodeURIComponent(s.replace(/\s+/g, '-'))
+export const fromPath = (s?: string) =>
+  s ? decodeURIComponent(s).replace(/-/g, ' ') : ''

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -7,7 +7,6 @@ export type StudyCardData = {
   memberCount?: number
   time: string
   category: string
-
 }
 
 export const dummyData: StudyCardData[] = [

--- a/src/pages/auth/MainPage.tsx
+++ b/src/pages/auth/MainPage.tsx
@@ -49,7 +49,7 @@ const MainPage = () => {
       <section className="py-6 px-4">
         <div className="max-w-[1400px] mx-auto mb-[88px]">
           <div className="flex items-center justify-between mb-[32px]">
-            <h2 className="text-[20px]] font-semibold">오늘의 HOT STUDY 10</h2>
+            <h2 className="text-[20px] font-semibold">오늘의 HOT STUDY 10</h2>
             <ArrowNavigation
               onPrev={() => setHotIndex((prev) => Math.max(prev - 1, 0))}
               onNext={() =>
@@ -91,7 +91,7 @@ const MainPage = () => {
       <section className="py-6 px-4">
         <div className="max-w-[1400px] mx-auto mb-[88px]">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-[20px]] font-semibold">NEW STUDY</h2>
+            <h2 className="text-[20px] font-semibold">NEW STUDY</h2>
             <ArrowNavigation
               onPrev={() => setNewIndex((prev) => Math.max(prev - 1, 0))}
               onNext={() =>

--- a/src/pages/category/CategoryDetailPage.tsx
+++ b/src/pages/category/CategoryDetailPage.tsx
@@ -1,35 +1,13 @@
-import { useParams } from 'react-router-dom'
 import { useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
 import SideCategoryMenu from '@/pages/category/SideCategoryMenu'
 import SortTab from '@/common/SortTab'
 import StudyCard from '@/common/StudyCard'
 import defaultThumbnail from '@/assets/images/default-thumbnail.png'
+import { dummyData } from '@/data/dummyData'
 
-const dummyData = [
-  {
-    imageUrl: defaultThumbnail,
-    title: 'Python 웹크롤링 데이터 분석반',
-    description:
-      'BeautifulSoup, Selenium으로 웹 데이터를 수집하고 분석하는 실전형 스터디입니다.',
-    memberCount: 4,
-    time: '월, 수 오후 8시',
-  },
-  {
-    imageUrl: defaultThumbnail,
-    title: 'React 클론코딩 프로젝트 스터디',
-    description:
-      '넷플릭스, 인스타그램 클론코딩으로 실무 감각을 익히고 포트폴리오를 함께 만들어봐요.',
-    memberCount: 6,
-    time: '토요일 오후 5시',
-  },
-  {
-    imageUrl: defaultThumbnail,
-    title: '알고리즘 문제풀이 매일 챌린지',
-    description: '코테 준비 OK! 매일 1문제 풀고 풀이 공유/토론으로 실력 상승!',
-    memberCount: 5,
-    time: '수요일 오후 3시',
-  },
-]
+// dummyData 아이템 타입 재사용
+type Study = (typeof dummyData)[number]
 
 const decodePath = (s?: string) =>
   s ? decodeURIComponent(s).replace(/-/g, ' ') : ''
@@ -41,21 +19,19 @@ export default function CategoryDetailPage() {
 
   const [sortOrder, setSortOrder] = useState<'latest' | 'popular'>('latest')
 
-  const list = useMemo(() => {
+  // ✅ 전역 dummyData 기반으로 목록 구성 (인기순/최신순)
+  const list = useMemo<Study[]>(() => {
+    const base = dummyData
     if (sortOrder === 'popular') {
-      return [...dummyData].sort(
+      return [...base].sort(
         (a, b) => (b.memberCount ?? 0) - (a.memberCount ?? 0)
       )
     }
-    return dummyData
+    return base
   }, [sortOrder])
 
-  const title =
-    category && subcategory
-      ? `${category} > ${subcategory} 스터디`
-      : category
-        ? `${category} 스터디`
-        : '전체 스터디'
+  // 상단 타이틀 고정
+  const title = '전체 스터디'
 
   return (
     <div className="w-full mt-[80px]">
@@ -74,14 +50,14 @@ export default function CategoryDetailPage() {
             {list.map((item, index) => (
               <StudyCard
                 key={index}
-                imageUrl={item.imageUrl}
+                variant="horizontal"
+                className="w-[360px]"
+                thumbnailRatio="w-[360px] h-[200px]"
+                imageUrl={item.imageUrl ?? defaultThumbnail}
                 title={item.title}
                 description={item.description}
                 memberCount={item.memberCount}
                 time={item.time}
-                variant="horizontal"
-                thumbnailRatio="w-[360px] h-[200px]"
-                className="w-[360px]"
               />
             ))}
           </div>

--- a/src/pages/category/CategoryDetailPage.tsx
+++ b/src/pages/category/CategoryDetailPage.tsx
@@ -13,22 +13,26 @@ const decodePath = (s?: string) =>
   s ? decodeURIComponent(s).replace(/-/g, ' ') : ''
 
 export default function CategoryDetailPage() {
-  const { category: rawCat, subcategory: rawSub } = useParams()
+  const { category: rawCat } = useParams()
   const category = decodePath(rawCat)
-  const subcategory = decodePath(rawSub)
 
   const [sortOrder, setSortOrder] = useState<'latest' | 'popular'>('latest')
 
-  // ✅ 전역 dummyData 기반으로 목록 구성 (인기순/최신순)
+  // 전역 dummyData 기반으로 목록 구성 (카테고리 필터 + 정렬)
   const list = useMemo<Study[]>(() => {
-    const base = dummyData
+    const base = category
+      ? dummyData.filter(
+          (d) => (d.category ?? '').toLowerCase() === category.toLowerCase()
+        )
+      : dummyData
+
     if (sortOrder === 'popular') {
       return [...base].sort(
         (a, b) => (b.memberCount ?? 0) - (a.memberCount ?? 0)
       )
     }
     return base
-  }, [sortOrder])
+  }, [category, sortOrder])
 
   // 상단 타이틀 고정
   const title = '전체 스터디'

--- a/src/pages/category/SideCategoryMenu.tsx
+++ b/src/pages/category/SideCategoryMenu.tsx
@@ -1,24 +1,26 @@
 import { NavLink, useParams } from 'react-router-dom'
-
-const sideMenu = {
-  category: 'IT · 프로그래밍',
-  items: ['전체', '웹 개발', '게임 개발'],
-}
+import { categoryData, fromPath, toPath } from '@/data/categoryData'
 
 export default function SideCategoryMenu() {
-  const { category } = useParams()
+  const { category: rawCategory } = useParams()
+  const categoryTitle = fromPath(rawCategory)
 
-  const getLink = (item: string) => {
-    return item === '전체'
-      ? `/category/${encodeURIComponent(category || '')}`
-      : `/category/${encodeURIComponent(category || '')}/${encodeURIComponent(item)}`
-  }
+  // 현재 대분류 찾기 (없으면 첫 번째로 fallback)
+  const currentCategory =
+    categoryData.find((c) => c.title === categoryTitle) ?? categoryData[0]
+
+  const menuItems = ['전체', ...currentCategory.items]
+
+  const getLink = (item: string) =>
+    item === '전체'
+      ? `/category/${toPath(currentCategory.title)}`
+      : `/category/${toPath(currentCategory.title)}/${toPath(item)}`
 
   return (
     <aside className="w-[200px] flex flex-col gap-[64px]">
-      <h2 className="text-[24px] font-semibold">{sideMenu.category}</h2>
+      <h2 className="text-[24px] font-semibold">{currentCategory.title}</h2>
       <ul className="flex flex-col gap-[24px]">
-        {sideMenu.items.map((item) => (
+        {menuItems.map((item) => (
           <li key={item}>
             <NavLink
               to={getLink(item)}

--- a/src/pages/search/SearchResultPage.tsx
+++ b/src/pages/search/SearchResultPage.tsx
@@ -1,11 +1,55 @@
+import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
+import { dummyData } from '@/data/dummyData'
+import StudyCard from '@/common/StudyCard'
+import SearchEmptyState from '@/components/search/SearchEmptyState'
+
+// dummyData 한 아이템의 타입 재사용
+type Study = (typeof dummyData)[number]
 
 export default function SearchResultPage() {
-  const { query } = useParams()
+  const { query } = useParams<{ query: string }>()
+
+  const results = useMemo<Study[]>(() => {
+    if (!query) return []
+    const lower = query.toLowerCase()
+
+    return dummyData.filter((item) => {
+      const title = (item.title ?? '').toLowerCase()
+      const desc = (item.description ?? '').toLowerCase()
+      const category = (item.category ?? '').toLowerCase()
+      return (
+        title.includes(lower) ||
+        desc.includes(lower) ||
+        category.includes(lower)
+      )
+    })
+  }, [query])
+
+  if (!query || results.length === 0) return <SearchEmptyState />
+
   return (
-    <>
-      <div className="text-2xl text-alertText">{query} </div>
-      <div className="text-2xl">검색 결과 페이지</div>
-    </>
+    <div className="w-[1400px] mx-auto px-[20px] py-[40px]">
+      <h2 className="text-[24px] font-bold mb-[32px]">
+        ‘{query}’으로 검색한 결과 입니다 ({results.length})
+      </h2>
+
+      {/* 3열 고정, 간격 40px */}
+      <div className="grid grid-cols-3 gap-[40px]">
+        {results.map((item, idx) => (
+          <StudyCard
+            key={`${item.title}-${idx}`}
+            variant="horizontal"
+            className="w-[440px]"
+            thumbnailRatio="w-[440px] h-[256px]"
+            imageUrl={item.imageUrl}
+            title={item.title}
+            description={item.description}
+            memberCount={item.memberCount}
+            time={item.time}
+          />
+        ))}
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
검색 결과 페이지 구현 및 SearchResultList 컴포넌트 분리

## ✅ PR 요약

- 관련 이슈 번호 : #115 
- 작업요약 : 어떤 작업을 했는지 간단하게 적어주세요

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 검색 결과 페이지(SearchResultPage)
- - 검색 결과 개수 표시 및 결과 없음 처리(SearchEmptyState 사용)

- SearchResultList 컴포넌트 분리
- - 필터링된 데이터를 받아 StudyCard 목록으로 렌더링
- SearchEmptyState 컴포넌트 추가

## 📸 스크린샷 (선택)
<img width="3420" height="2936" alt="screencapture-localhost-5173-search-2025-08-08-18_20_58" src="https://github.com/user-attachments/assets/39c06ca0-f1af-4786-9c08-68511eb3fc09" />
<img width="3420" height="1928" alt="screencapture-localhost-5173-search-2025-08-08-18_21_24" src="https://github.com/user-attachments/assets/e2559271-1820-43fd-95b9-0232a0a5c127" />


## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
