### PR TITLE
✨ feat: 외부클릭 시닫 힘 커스터훅 useClickOutside 구현 및 공통 모달에 적용

### DIFF
--- a/src/common/CommonModal.tsx
+++ b/src/common/CommonModal.tsx
@@ -1,6 +1,7 @@
-import { type PropsWithChildren, type ReactNode } from 'react'
+import { type PropsWithChildren, type ReactNode, useRef } from 'react'
 import { IoIosClose } from 'react-icons/io'
 import ModalWrapper from '@/common/ModalWrapper'
+import useClickOutside from '@/hooks/useClickOutside'
 
 interface CommonModalBaseProps {
   isOpen: boolean
@@ -22,10 +23,17 @@ export default function CommonModal({
   children,
   className,
 }: CommonModalProps) {
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  useClickOutside(dropdownRef, () => {
+    if (isOpen) {
+      onClose()
+    }
+  })
+
   if (!isOpen) return null
 
   return (
-    <ModalWrapper className={className}>
+    <ModalWrapper className={className} ref={dropdownRef}>
       {/* X 버튼 */}
       <button
         className="absolute top-4 right-4 text-[#BDBDBD] text-xl cursor-pointer"

--- a/src/common/ModalWrapper.tsx
+++ b/src/common/ModalWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 
 interface ModalWrapperProps {
   children: React.ReactNode // 모달 내부 콘텐츠
@@ -6,20 +6,21 @@ interface ModalWrapperProps {
   className?: string // 외부에서 전달받은 커스텀 스타일
 }
 
-const ModalWrapper: React.FC<ModalWrapperProps> = ({
-  children,
-  width = 'w-[396px]',
-  className = '',
-}) => {
-  return (
-    <div className="fixed inset-0 bg-[rgba(18,18,18,0.6)] z-50 flex justify-center items-center">
-      <div
-        className={`bg-white ${width} rounded-xl p-[24px] relative flex flex-col items-center justify-center ${className}`}
-      >
-        {children}
+const ModalWrapper = forwardRef<HTMLDivElement, ModalWrapperProps>(
+  ({ children, width = 'w-[396px]', className = '' }, ref) => {
+    return (
+      <div className="fixed inset-0 bg-[rgba(18,18,18,0.6)] z-50 flex justify-center items-center">
+        <div
+          ref={ref}
+          className={`bg-white ${width} rounded-xl p-[24px] relative flex flex-col items-center justify-center ${className}`}
+        >
+          {children}
+        </div>
       </div>
-    </div>
-  )
-}
+    )
+  }
+)
+
+ModalWrapper.displayName = 'ModalWrapper'
 
 export default ModalWrapper

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,30 @@
+//외부 클릭 시 모달닫힘 커스텀 훅
+// 사용법
+// useClickOutside(dropdownRef, () => {
+//   if (isOpen) {
+//     setIsOpen(false);
+//   }
+// });
+
+import { useEffect, type RefObject } from 'react'
+
+export default function useClickOutside<T extends HTMLElement>(
+  dropdownRef: RefObject<T | null>,
+  handler: (event: MouseEvent | TouchEvent) => void
+) {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!(event.target instanceof Node)) return
+      if (!dropdownRef?.current || dropdownRef?.current.contains(event.target))
+        return
+      handler(event)
+    }
+    document.addEventListener('mousedown', listener)
+    document.addEventListener('touchstart', listener)
+
+    return () => {
+      document.removeEventListener('mousedown', listener)
+      document.removeEventListener('touchstart', listener)
+    }
+  }, [dropdownRef, handler])
+}


### PR DESCRIPTION


## ✅ PR 요약

- 관련 이슈 번호 : #117
- 작업요약 : 외부클릭 시닫 힘 커스터훅 useClickOutside 구현 및 공통 모달에 적용

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 외부 클릭 시 닫을 수 있는 useClickOutside 커스텀 훅 구현
- CommonModal 및 모달을 감싸는 ModalWrapper 컴포넌트에 적용

## 📸 스크린샷 (선택)

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
