### PR TITLE
✨ feat: 스터디룸 모달 구현(신고하기,데일리미션,쪽지)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,7 +117,7 @@ export default function App() {
         <Route path="/privacy" element={<PrivacyPolicyPage />} />
         <Route path="/contact" element={<ContactPage />} />
       </Route>
-      <Route path="/study/:roomid" element={<StudyRoomPage />} />
+      <Route path="/study/:roomId" element={<StudyRoomPage />} />
     </Routes>
   )
 }

--- a/src/common/MissionModal.tsx
+++ b/src/common/MissionModal.tsx
@@ -8,7 +8,7 @@ import TransientModal from '@/common/TransientModal.tsx'
 interface MissionModalProps {
   isOpen: boolean
   onClose: () => void
-  onStart: () => void
+  onStart?: () => void
   title: string
   subtitle: ReactNode | string
 }
@@ -141,7 +141,9 @@ export default function MissionModal({
               className="h-[48px] text-base"
               variant="primary"
               onClick={() => {
-                onStart()
+                if (onStart) {
+                  onStart()
+                }
                 onClose()
                 setMissions(['오늘은 목숨부터 정복할겁니다'])
                 setEditIndex(null)

--- a/src/components/study/studyRoomPage/KonvaWhiteBoard.tsx
+++ b/src/components/study/studyRoomPage/KonvaWhiteBoard.tsx
@@ -27,6 +27,7 @@ export default function Whiteboard({
 
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 })
 
+  //화이트보드 사이즈 부모 사이즈 기준으로 적용
   useEffect(() => {
     if (!containerRef.current) return
     const updateSize = () => {

--- a/src/components/study/studyRoomPage/StudyRoomInboxMessage.tsx
+++ b/src/components/study/studyRoomPage/StudyRoomInboxMessage.tsx
@@ -1,0 +1,56 @@
+import defaultUserImg from '@/assets/images/default-profile.png'
+import CommonButton from '@/common/CommonButton'
+import InputField from '@/common/InputField'
+import type { InboxMessage } from '@/types/message'
+import { toCustomDate } from '@/utils/toCustomDate'
+import { useState } from 'react'
+import { MdKeyboardArrowUp, MdKeyboardArrowDown } from 'react-icons/md'
+
+export default function StudyRoomInboxMessage({
+  message,
+}: {
+  message: InboxMessage
+}) {
+  const [isDetailMessageOpen, setIsDetailMessageOpen] = useState(false)
+  return (
+    <div className="mt-6 w-full">
+      <div className="flex text-[16px] gap-[10px] text-text">
+        <img
+          src={defaultUserImg}
+          alt="흩어지면뽂음밥 님의 유저 이미지"
+          className="w-[48px] rounded-full"
+        />
+        <div className="flex flex-col gap-[4px] w-[344px]">
+          <div className="flex justify-between">
+            <div className="truncate">
+              {message.type === 'personal'
+                ? message.sender
+                : `[${message.title}]`}
+            </div>
+            <div
+              className="flex items-center justify-center gap-[5px] text-disabled-text cursor-pointer"
+              onClick={() => setIsDetailMessageOpen((prev) => !prev)}
+            >
+              <div className="w-[100px]">{toCustomDate(message.sentAt)}</div>
+              {isDetailMessageOpen ? (
+                <MdKeyboardArrowUp size={25} />
+              ) : (
+                <MdKeyboardArrowDown size={25} />
+              )}
+            </div>
+          </div>
+          <div className="text-[12px] truncate">{message.content}</div>
+        </div>
+      </div>
+      {isDetailMessageOpen && (
+        <div className="flex flex-col gap-[24px] w-[408px] h-[144px] bg-secondary rounded-[8px] mt-[24px] p-[16px]">
+          <div className="text-text text-[16px]">{message.content}</div>
+          <div className="flex h-[48px] gap-[8px]">
+            <InputField className="bg-white h-[48px] w-[280px]" />
+            <CommonButton>전송</CommonButton>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/study/studyRoomPage/StudyRoomMessageInboxModal.tsx
+++ b/src/components/study/studyRoomPage/StudyRoomMessageInboxModal.tsx
@@ -1,0 +1,66 @@
+import { type PropsWithChildren, type ReactNode } from 'react'
+import { IoIosClose } from 'react-icons/io'
+import ModalWrapper from '@/common/ModalWrapper'
+import { useInboxMessageStore } from '@/store/useInboxMessageStore'
+import StudyRoomInboxMessage from '@/components/study/studyRoomPage/StudyRoomInboxMessage'
+import CommonButton from '@/common/CommonButton'
+
+interface CommonModalBaseProps {
+  isOpen: boolean
+  onClose: () => void
+  Icon?: React.ReactElement
+  title: string
+  subtitle?: ReactNode
+  className?: string
+}
+
+type CommonModalProps = PropsWithChildren<CommonModalBaseProps>
+
+export default function StudyRoomMessageInboxModal({
+  isOpen,
+  onClose,
+  Icon,
+  title,
+  subtitle,
+  className,
+}: CommonModalProps) {
+  const inboxMessages = useInboxMessageStore((state) => state.inboxMessages)
+
+  if (!isOpen) return null
+
+  const handleOpenInboxMessage = () => {
+    window.open('/mypage/messages/inbox', '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <ModalWrapper className={className}>
+      {/* X 버튼 */}
+      <button
+        className="absolute top-4 right-4 text-[#BDBDBD] text-xl cursor-pointer"
+        onClick={onClose}
+      >
+        <IoIosClose />
+      </button>
+      {Icon}
+      {/* 타이틀 */}
+      <h2 className="text-center mt-[20px] text-[24px] font-bold text-[#8349FF]">
+        {title}
+      </h2>
+      {subtitle && (
+        <p className="mt-[8px] text-center text-[16px] text-[#BDBDBD]">
+          {subtitle}
+        </p>
+      )}
+
+      {/* 콘텐츠 */}
+      <div className="overflow-scroll scrollbar-hide mt-[40px] mb-[48px] h-[400px]">
+        {inboxMessages.map((message) => (
+          <StudyRoomInboxMessage key={message.id} message={message} />
+        ))}
+      </div>
+      <CommonButton className="h-[48px]" onClick={handleOpenInboxMessage}>
+        전체 쪽지함 보기
+      </CommonButton>
+    </ModalWrapper>
+  )
+}

--- a/src/components/study/studyRoomPage/StudyRoomSendMessageModal.tsx
+++ b/src/components/study/studyRoomPage/StudyRoomSendMessageModal.tsx
@@ -1,0 +1,59 @@
+import { type PropsWithChildren } from 'react'
+import { IoIosClose } from 'react-icons/io'
+import ModalWrapper from '@/common/ModalWrapper'
+import CommonButton from '@/common/CommonButton'
+
+interface CommonModalBaseProps {
+  isOpen: boolean
+  onClose: () => void
+  title: string
+  className?: string
+  messageSender: string
+}
+
+type CommonModalProps = PropsWithChildren<CommonModalBaseProps>
+
+export default function StudyRoomSendMessageModal({
+  isOpen,
+  onClose,
+  title,
+  className,
+  messageSender,
+}: CommonModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <ModalWrapper className={className}>
+      {/* X 버튼 */}
+      <button
+        className="absolute top-4 right-4 text-[#BDBDBD] text-xl cursor-pointer"
+        onClick={onClose}
+      >
+        <IoIosClose />
+      </button>
+      {/* 타이틀 */}
+      <h2 className="text-center mt-[20px] text-[24px] font-bold text-[#8349FF]">
+        {title}
+      </h2>
+
+      {/* 콘텐츠 */}
+      <div className="mt-6 w-full">
+        <div className="flex text-[16px] gap-[16px]">
+          <div className="font-semibold">받는사람</div>
+          <div>{messageSender}</div>
+        </div>
+      </div>
+      <div className="flex flex-col self-start mt-[16px] text-[16px] text-text gap-[16px]">
+        <div className="flex">
+          <div className="font-semibold">메세지</div>
+          <div className="text-alertText ">*</div>
+        </div>
+        <textarea
+          className="w-[480px] h-[104px] border border-[#bdbdbd] rounded-[4px] bg-white resize-none overflow-hidden px-[16px] py-[10px] placeholder:text-[14px] placeholder:text-[#bdbdbd]"
+          placeholder="메세지를 작성해주세요"
+        />
+      </div>
+      <CommonButton className="mt-[16px]">쪽지 보내기</CommonButton>
+    </ModalWrapper>
+  )
+}

--- a/src/components/study/studyRoomPage/StudyRoomUserCard.tsx
+++ b/src/components/study/studyRoomPage/StudyRoomUserCard.tsx
@@ -4,8 +4,20 @@ import { PiCrownSimpleFill } from 'react-icons/pi'
 import type { StudyCardData } from '@/mystudymockdata/studyRoomMockData'
 import { cn } from '@/utils/cn'
 
-export default function StudyRoomUserCard({ user }: { user: StudyCardData }) {
+export default function StudyRoomUserCard({
+  user,
+  setMessageSender,
+  setIsMessageSendModal,
+}: {
+  user: StudyCardData
+  setMessageSender: React.Dispatch<React.SetStateAction<string | null>>
+  setIsMessageSendModal: React.Dispatch<React.SetStateAction<boolean>>
+}) {
   const { userProfile, nickname, dailyMissions, isMe, isLeader } = user
+  const handleSendMessageModalOpen = () => {
+    setMessageSender(nickname)
+    setIsMessageSendModal(true)
+  }
   return (
     <div
       className={cn(
@@ -34,7 +46,12 @@ export default function StudyRoomUserCard({ user }: { user: StudyCardData }) {
             />
           </div>
           <div className="flex gap-[8px] text-[#a2a2a2]">
-            <button className="cursor-pointer">쪽지보내기</button>
+            <button
+              className="cursor-pointer"
+              onClick={handleSendMessageModalOpen}
+            >
+              쪽지보내기
+            </button>
             <button className="cursor-pointer">프로필 보기</button>
           </div>
         </div>

--- a/src/pages/study/StudyRoomPage.tsx
+++ b/src/pages/study/StudyRoomPage.tsx
@@ -13,6 +13,7 @@ import MissionModal from '@/common/MissionModal'
 import { useParams } from 'react-router-dom'
 import defaultPrfileImag from '@/assets/images/default-profile.png'
 import StudyRoomMessageInboxModal from '@/components/study/studyRoomPage/StudyRoomMessageInboxModal'
+import StudyRoomSendMessageModal from '@/components/study/studyRoomPage/StudyRoomSendMessageModal'
 
 const reportModalDropdownOption = [
   { label: '부적절한 스터디 내용', value: '1' },
@@ -31,6 +32,8 @@ export default function StudyRoomPage() {
   const [isMessageInboxModalOpen, setIsMessageInboxModalOpen] = useState(false)
   const [selectReportModalDropdownOption, setSelectReportModalDropdownOption] =
     useState('')
+  const [isMessageSendModal, setIsMessageSendModal] = useState(false)
+  const [messageSender, setMessageSender] = useState<string | null>(null)
   const { roomId } = useParams()
   const containerRef = useRef<HTMLDivElement>(null)
   const user = useUserInfo((state) => state.userInfo?.user)
@@ -125,7 +128,14 @@ export default function StudyRoomPage() {
               onClose={() => setIsMessageInboxModalOpen(false)}
               title="쪽지함"
               className="p-[30px] w-[488px] max-h-[712px] justify-start"
-            ></StudyRoomMessageInboxModal>
+            />
+            <StudyRoomSendMessageModal
+              isOpen={isMessageSendModal}
+              onClose={() => setIsMessageSendModal(false)}
+              title="쪽지 보내기"
+              messageSender={messageSender ?? ''}
+              className="w-[560px] p-[40px]"
+            />
           </div>
         </div>
         <div className="flex gap-[16px] items-center">
@@ -171,7 +181,12 @@ export default function StudyRoomPage() {
             </div>
           </div>
           {studyRoomUserCardMockData.map((user, index) => (
-            <StudyRoomUserCard key={`${user.nickname}-${index}`} user={user} />
+            <StudyRoomUserCard
+              key={`${user.nickname}-${index}`}
+              user={user}
+              setMessageSender={setMessageSender}
+              setIsMessageSendModal={setIsMessageSendModal}
+            />
           ))}
         </div>
       </div>

--- a/src/pages/study/StudyRoomPage.tsx
+++ b/src/pages/study/StudyRoomPage.tsx
@@ -12,6 +12,7 @@ import CommonButton from '@/common/CommonButton'
 import MissionModal from '@/common/MissionModal'
 import { useParams } from 'react-router-dom'
 import defaultPrfileImag from '@/assets/images/default-profile.png'
+import StudyRoomMessageInboxModal from '@/components/study/studyRoomPage/StudyRoomMessageInboxModal'
 
 const reportModalDropdownOption = [
   { label: '부적절한 스터디 내용', value: '1' },
@@ -26,9 +27,10 @@ const reportModalDropdownOption = [
 export default function StudyRoomPage() {
   const [isOpenTitleMenuModal, setIsOpenTitleMenuModal] = useState(false)
   const [isReprotModalOpen, setReportModalOpen] = useState(false)
+  const [isDailyModalOpen, setIsDailyModalOpen] = useState(false)
+  const [isMessageInboxModalOpen, setIsMessageInboxModalOpen] = useState(false)
   const [selectReportModalDropdownOption, setSelectReportModalDropdownOption] =
     useState('')
-  const [isDailyModalOpen, setIsDailyModalOpen] = useState(false)
   const { roomId } = useParams()
   const containerRef = useRef<HTMLDivElement>(null)
   const user = useUserInfo((state) => state.userInfo?.user)
@@ -118,6 +120,12 @@ export default function StudyRoomPage() {
                 }
               />
             )}
+            <StudyRoomMessageInboxModal
+              isOpen={isMessageInboxModalOpen}
+              onClose={() => setIsMessageInboxModalOpen(false)}
+              title="쪽지함"
+              className="p-[30px] w-[488px] max-h-[712px] justify-start"
+            ></StudyRoomMessageInboxModal>
           </div>
         </div>
         <div className="flex gap-[16px] items-center">
@@ -128,7 +136,11 @@ export default function StudyRoomPage() {
           />
           <div className="flex gap-[8px] items-center">
             <div className="text-[18px] text-text1">{user?.nickname}</div>
-            <CiMail size={20} className="text-[#bdbdbd] cursor-pointer" />
+            <CiMail
+              size={20}
+              className="text-[#bdbdbd] cursor-pointer"
+              onClick={() => setIsMessageInboxModalOpen((prev) => !prev)}
+            />
             <IoIosLogOut size={20} className="text-[#bdbdbd] cursor-pointer" />
           </div>
         </div>

--- a/src/pages/study/StudyRoomPage.tsx
+++ b/src/pages/study/StudyRoomPage.tsx
@@ -2,18 +2,99 @@
 import Whiteboard from '@/components/study/studyRoomPage/KonvaWhiteBoard'
 import StudyRoomUserCard from '@/components/study/studyRoomPage/StudyRoomUserCard'
 import { studyRoomUserCardMockData } from '@/mystudymockdata/studyRoomMockData'
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { useUserInfo } from '@/store/userInfoStore'
 import { CiMail } from 'react-icons/ci'
-import { IoIosLogOut } from 'react-icons/io'
+import { IoIosLogOut, IoMdMore } from 'react-icons/io'
+import CommonModal from '@/common/CommonModal'
+import Dropdown from '@/common/DropDown'
+import CommonButton from '@/common/CommonButton'
+
+const reportModalDropdownOption = [
+  { label: '부적절한 스터디 내용', value: '1' },
+  { label: '스터디장의 비매너 행동', value: '2' },
+  { label: '금전 관련 문제', value: '3' },
+  { label: '욕설 및 비방', value: '4' },
+  { label: '스팸 및 도배', value: '5' },
+  { label: '개인정보 오남용', value: '6' },
+  { label: '기타(직접 작성)', value: '7' },
+]
 
 export default function StudyRoomPage() {
+  const [isOpenTitleMenuModal, setIsOpenTitleMenuModal] = useState(false)
+  const [isReprotModalOpen, setReportModalOpen] = useState(false)
+  const [selectReportModalDropdownOption, setSelectReportModalDropdownOption] =
+    useState('')
   const containerRef = useRef<HTMLDivElement>(null)
   const user = useUserInfo((state) => state.userInfo?.user)
   return (
     <div>
       <div className="flex text-[32px] h-[136px] w-full items-center justify-between px-[72px] border-b-[1px] border-b-[#e6e6e6]">
-        <div>알고리즘 마스터 스터디</div>
+        <div className="flex items-center gap-[4px]">
+          <div>알고리즘 마스터 스터디</div>
+          <div className="relative">
+            <IoMdMore
+              size={25}
+              onClick={() => setIsOpenTitleMenuModal((prev) => !prev)}
+              className="cursor-pointer"
+            />
+            {isOpenTitleMenuModal && (
+              <div className="flex justify-center items-center absolute top-[30px] w-[120px] h-[40px] bg-white rounded-md shadow-lg z-10">
+                <div
+                  className="text-base cursor-pointer"
+                  onClick={() => {
+                    setIsOpenTitleMenuModal(false)
+                    setReportModalOpen(true)
+                  }}
+                >
+                  스터디 신고하기
+                </div>
+              </div>
+            )}
+            <CommonModal
+              title="스터디 신고"
+              isOpen={isReprotModalOpen}
+              onClose={() => setReportModalOpen(false)}
+              className="w-[560px] h-[598px] p-[40px]"
+            >
+              <div className="flex flex-col items-center">
+                <div className="flex flex-col items-center justify-center text-[16px] text-text4">
+                  <div>불쾌하거나 부적절한 상황이 발생했다면 신고해주세요.</div>
+                  <div>모든 신고는 비공개로 처리됩니다.</div>
+                </div>
+                <div className="flex flex-col self-start mt-[40px] text-[16px] text-text gap-[16px]">
+                  <div className="flex">
+                    <div>신고사유</div>
+                    <div className="text-alertText">*</div>
+                  </div>
+                  <Dropdown
+                    options={reportModalDropdownOption}
+                    placeholder="선택해 주세요"
+                    selected={selectReportModalDropdownOption}
+                    onChange={setSelectReportModalDropdownOption}
+                    className="w-[276px]"
+                  />
+                </div>
+                <div className="flex flex-col self-start mt-[40px] text-[16px] text-text gap-[16px]">
+                  <div className="flex">
+                    <div>상세설명</div>
+                    <div className="text-alertText ">*</div>
+                  </div>
+                  <textarea
+                    className="w-[480px] h-[104px] border border-[#bdbdbd] rounded-[4px] bg-white resize-none overflow-hidden px-[16px] py-[10px] placeholder:text-[14px] placeholder:text-[#bdbdbd]"
+                    placeholder="이유를 작성해주세요"
+                  />
+                </div>
+                <CommonButton
+                  className="mt-[40px]"
+                  onClick={() => setReportModalOpen(false)}
+                >
+                  신고하기
+                </CommonButton>
+              </div>
+            </CommonModal>
+          </div>
+        </div>
         <div className="flex gap-[16px] items-center">
           <img
             src={user?.profile_image_url}

--- a/src/pages/study/StudyRoomPage.tsx
+++ b/src/pages/study/StudyRoomPage.tsx
@@ -2,13 +2,16 @@
 import Whiteboard from '@/components/study/studyRoomPage/KonvaWhiteBoard'
 import StudyRoomUserCard from '@/components/study/studyRoomPage/StudyRoomUserCard'
 import { studyRoomUserCardMockData } from '@/mystudymockdata/studyRoomMockData'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useUserInfo } from '@/store/userInfoStore'
 import { CiMail } from 'react-icons/ci'
 import { IoIosLogOut, IoMdMore } from 'react-icons/io'
 import CommonModal from '@/common/CommonModal'
 import Dropdown from '@/common/DropDown'
 import CommonButton from '@/common/CommonButton'
+import MissionModal from '@/common/MissionModal'
+import { useParams } from 'react-router-dom'
+import defaultPrfileImag from '@/assets/images/default-profile.png'
 
 const reportModalDropdownOption = [
   { label: '부적절한 스터디 내용', value: '1' },
@@ -25,8 +28,17 @@ export default function StudyRoomPage() {
   const [isReprotModalOpen, setReportModalOpen] = useState(false)
   const [selectReportModalDropdownOption, setSelectReportModalDropdownOption] =
     useState('')
+  const [isDailyModalOpen, setIsDailyModalOpen] = useState(false)
+  const { roomId } = useParams()
   const containerRef = useRef<HTMLDivElement>(null)
   const user = useUserInfo((state) => state.userInfo?.user)
+
+  useEffect(() => {
+    if (roomId) {
+      setIsDailyModalOpen(true)
+    }
+  }, [roomId])
+
   return (
     <div>
       <div className="flex text-[32px] h-[136px] w-full items-center justify-between px-[72px] border-b-[1px] border-b-[#e6e6e6]">
@@ -93,11 +105,24 @@ export default function StudyRoomPage() {
                 </CommonButton>
               </div>
             </CommonModal>
+            {isDailyModalOpen && (
+              <MissionModal
+                isOpen={isDailyModalOpen}
+                onClose={() => setIsDailyModalOpen(false)}
+                title="데일리 미션"
+                subtitle={
+                  <p className="whitespace-pre-line text-sm text-text4 text-center">
+                    내가 오늘 꼭 달성하고 싶은 목표를 설정해주세요!
+                    {'\n'}최대 5개까지 설정할 수 있습니다.
+                  </p>
+                }
+              />
+            )}
           </div>
         </div>
         <div className="flex gap-[16px] items-center">
           <img
-            src={user?.profile_image_url}
+            src={user?.profile_image_url ?? defaultPrfileImag}
             alt="유저프로피이미지"
             className="rounded-full w-[64px]"
           />

--- a/src/utils/toCustomDate.ts
+++ b/src/utils/toCustomDate.ts
@@ -1,0 +1,8 @@
+export const toCustomDate = (dateStr: string) => {
+  const d = new Date(dateStr)
+  if (d.getHours() === 0 && d.getMinutes() === 0) {
+    d.setDate(d.getDate() - 1)
+    return `${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')} 24:00`
+  }
+  return `${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #107, #108, #109
- 작업요약 : 스터디룸 신고하기, 데일리미션, 쪽지 모달 구현

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->


- 데일리미션 수정 모달
  - 나의 스터디의 스터디 시작 모달을 공용으로 사용합니다.(onStart Prop을 선택으로 수정)
  - 스터디룸 진입 시 데일리 미션 수정 모달이 나타 납니다.
  - 스터디룸 진입 시 useEffect 와 useParams를 사용하여 URL상에 roomId를 확인 후 모달창을 생성합니다.
  
- 스터디룸 신고하기 모달
  - 스터디룸 title 옆의 드롭다운 메뉴를 클릭 하면 신고하기 버튼이 나타납니다.
  - 신고하기 버튼 클릭 시 스터디 신고하기 모달이 나타 납니다.

- 쪽지함 모달
  - 스터디룸 우측 상단의 편지아이콘을 클릭하면 쪽지함 모달이 나타 납니다.
  - 받은 쪽지함의 데이터를 전역에서 불러오며, 마이페이지의 받은 쪽지함 데이터를 공유합니다.
- 쪽지보내기 모달
  - 유저 카드에서 쪽지 보내기를 클릭하면 쪽지 보내기 모달이 나타 납니다.
  - 카드의 유저 닉네임을 불러와 받는 사람 옆에 보여줍니다.

## 📸 스크린샷 (선택)

<데일리미션 수정 모달>
<img width="300" alt="CleanShot 2025-08-08 at 23 13 58@2x" src="https://github.com/user-attachments/assets/412ae230-1134-4f9b-bdd0-c0fd887e207e" />

<신고하기 버튼 드롭다운>
<img width="300" alt="CleanShot 2025-08-08 at 23 14 45@2x" src="https://github.com/user-attachments/assets/bd22b2bb-e197-407c-9b4c-d4d7e2b7016f" />

<스터디 신고 모달>
<img width="300" alt="CleanShot 2025-08-08 at 23 15 01@2x" src="https://github.com/user-attachments/assets/dce4a660-629d-435d-983e-6bcb2e4518dd" />

<쪽지함 모달>
<img width="300" alt="CleanShot 2025-08-08 at 23 16 44@2x" src="https://github.com/user-attachments/assets/cd0d9f98-44a9-489e-947f-e177fb35b2df" />

<쪽지 보내기 모달>
<img width="300"  alt="CleanShot 2025-08-08 at 23 17 20@2x" src="https://github.com/user-attachments/assets/4d53404e-bd9e-46ed-accf-a5df6154c816" />


<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
