### PR TITLE
✨ feat: 스터디룸 프로필 보기 모달 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,6 @@ import UpdateEventPage from '@/admin/events/UpdateEvent.tsx'
 import CategoryShortcutPage from '@/pages/category/CategoryShortcutPage'
 import CustomRecommendPage from '@/pages/category/CustomRecommendPage'
 
-
 export default function App() {
   return (
     <Routes>

--- a/src/components/study/studyRoomPage/StudyRoomMessageInboxModal.tsx
+++ b/src/components/study/studyRoomPage/StudyRoomMessageInboxModal.tsx
@@ -1,9 +1,10 @@
-import { type PropsWithChildren, type ReactNode } from 'react'
+import { useRef, type PropsWithChildren, type ReactNode } from 'react'
 import { IoIosClose } from 'react-icons/io'
 import ModalWrapper from '@/common/ModalWrapper'
 import { useInboxMessageStore } from '@/store/useInboxMessageStore'
 import StudyRoomInboxMessage from '@/components/study/studyRoomPage/StudyRoomInboxMessage'
 import CommonButton from '@/common/CommonButton'
+import useClickOutside from '@/hooks/useClickOutside'
 
 interface CommonModalBaseProps {
   isOpen: boolean
@@ -25,6 +26,12 @@ export default function StudyRoomMessageInboxModal({
   className,
 }: CommonModalProps) {
   const inboxMessages = useInboxMessageStore((state) => state.inboxMessages)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  useClickOutside(dropdownRef, () => {
+    if (isOpen) {
+      onClose()
+    }
+  })
 
   if (!isOpen) return null
 
@@ -33,7 +40,7 @@ export default function StudyRoomMessageInboxModal({
   }
 
   return (
-    <ModalWrapper className={className}>
+    <ModalWrapper className={className} ref={dropdownRef}>
       {/* X 버튼 */}
       <button
         className="absolute top-4 right-4 text-[#BDBDBD] text-xl cursor-pointer"

--- a/src/components/study/studyRoomPage/StudyRoomSendMessageModal.tsx
+++ b/src/components/study/studyRoomPage/StudyRoomSendMessageModal.tsx
@@ -1,7 +1,8 @@
-import { type PropsWithChildren } from 'react'
+import { useRef, type PropsWithChildren } from 'react'
 import { IoIosClose } from 'react-icons/io'
 import ModalWrapper from '@/common/ModalWrapper'
 import CommonButton from '@/common/CommonButton'
+import useClickOutside from '@/hooks/useClickOutside'
 
 interface CommonModalBaseProps {
   isOpen: boolean
@@ -20,10 +21,16 @@ export default function StudyRoomSendMessageModal({
   className,
   messageSender,
 }: CommonModalProps) {
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  useClickOutside(dropdownRef, () => {
+    if (isOpen) {
+      onClose()
+    }
+  })
   if (!isOpen) return null
 
   return (
-    <ModalWrapper className={className}>
+    <ModalWrapper className={className} ref={dropdownRef}>
       {/* X 버튼 */}
       <button
         className="absolute top-4 right-4 text-[#BDBDBD] text-xl cursor-pointer"

--- a/src/components/study/studyRoomPage/StudyRoomUserCard.tsx
+++ b/src/components/study/studyRoomPage/StudyRoomUserCard.tsx
@@ -1,15 +1,22 @@
 import { AiOutlineCheckCircle } from 'react-icons/ai'
 import { IoSettingsOutline } from 'react-icons/io5'
 import { PiCrownSimpleFill } from 'react-icons/pi'
-import type { StudyCardData } from '@/mystudymockdata/studyRoomMockData'
 import { cn } from '@/utils/cn'
+import defaultUserImg from '@/assets/images/default-profile.png'
+import type { StudyCardDataType } from '@/types/StudyCardDataType'
 
 export default function StudyRoomUserCard({
   user,
+  setIsUserProfileModalOpen,
+  setSelectedUserProfile,
   setMessageSender,
   setIsMessageSendModal,
 }: {
-  user: StudyCardData
+  user: StudyCardDataType
+  setIsUserProfileModalOpen: React.Dispatch<React.SetStateAction<boolean>>
+  setSelectedUserProfile: React.Dispatch<
+    React.SetStateAction<StudyCardDataType | null>
+  >
   setMessageSender: React.Dispatch<React.SetStateAction<string | null>>
   setIsMessageSendModal: React.Dispatch<React.SetStateAction<boolean>>
 }) {
@@ -27,9 +34,18 @@ export default function StudyRoomUserCard({
     >
       <div className="flex gap-[16px]">
         <img
-          src={userProfile}
+          src={userProfile ?? defaultUserImg}
           alt="스터티개인프로필이미지"
-          className="h-[41px] rounded-full"
+          className="h-[41px] rounded-full cursor-pointer"
+          onError={(e) => {
+            if (e.currentTarget.src !== defaultUserImg) {
+              e.currentTarget.src = defaultUserImg
+            }
+          }}
+          onClick={() => {
+            setSelectedUserProfile(user)
+            setIsUserProfileModalOpen((prev) => !prev)
+          }}
         />
         <div className="flex flex-col gap-[2px] w-full">
           <div className="flex w-full items-center justify-between">
@@ -52,7 +68,12 @@ export default function StudyRoomUserCard({
             >
               쪽지보내기
             </button>
-            <button className="cursor-pointer">프로필 보기</button>
+            <button
+              className="cursor-pointer"
+              onClick={() => setIsUserProfileModalOpen(true)}
+            >
+              프로필 보기
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/study/studyRoomPage/StudyRoomUserProfileModal.tsx
+++ b/src/components/study/studyRoomPage/StudyRoomUserProfileModal.tsx
@@ -1,0 +1,92 @@
+import { useRef, type PropsWithChildren } from 'react'
+import { IoIosClose } from 'react-icons/io'
+import ModalWrapper from '@/common/ModalWrapper'
+import type { StudyCardDataType } from '@/types/StudyCardDataType'
+import defaultUserImg from '@/assets/images/default-profile.png'
+import StudyTag from '@/common/tag/StudyTag'
+import { FaFireAlt } from 'react-icons/fa'
+import { BsClock } from 'react-icons/bs'
+import CommonButton from '@/common/CommonButton'
+import useClickOutside from '@/hooks/useClickOutside'
+
+interface CommonModalBaseProps {
+  isOpen: boolean
+  onClose: () => void
+  title: string
+  className?: string
+  selectedUserProfile: StudyCardDataType | null
+}
+
+type CommonModalProps = PropsWithChildren<CommonModalBaseProps>
+
+export default function StudyRoomUserProfileModal({
+  isOpen,
+  onClose,
+  title,
+  className,
+  selectedUserProfile,
+}: CommonModalProps) {
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  useClickOutside(dropdownRef, () => {
+    if (isOpen) {
+      onClose()
+    }
+  })
+  if (!isOpen || !selectedUserProfile) return null
+  const { userProfile, nickname } = selectedUserProfile
+
+  return (
+    <ModalWrapper className={className} ref={dropdownRef}>
+      {/* X 버튼 */}
+      <button
+        className="absolute top-4 right-4 text-[#BDBDBD] text-xl cursor-pointer"
+        onClick={onClose}
+      >
+        <IoIosClose />
+      </button>
+      {/* 타이틀 */}
+      <h2 className="text-center mt-[20px] text-[24px] font-bold text-[#8349FF]">
+        {title}
+      </h2>
+      <img
+        src={userProfile ?? defaultUserImg}
+        alt={`${nickname}의 유저 이미지`}
+        onError={(e) => {
+          if (e.currentTarget.src !== defaultUserImg) {
+            e.currentTarget.src = defaultUserImg
+          }
+        }}
+        className="rounded-full w-[144px] mt-[32px]"
+      />
+      {/* 콘텐츠 */}
+      <div className="mt-[32px] w-full">
+        <div className="flex gap-[16px] justify-center">
+          <StudyTag variant="level" text="왕초급" />
+          <div>{nickname}</div>
+        </div>
+        <div className="flex flex-col gap-[8px] mt-[32px] text-[20px] text-text">
+          <div className="flex items-center justify-between">
+            <div className="flex gap-[12px] items-center">
+              <FaFireAlt className="text-primary" />
+              <div>연속출석</div>
+            </div>
+            <div>7일</div>
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="flex gap-[12px] items-center">
+              <BsClock className="text-primary" />
+              <div>총스터디시간</div>
+            </div>
+            <div>9999시간</div>
+          </div>
+        </div>
+      </div>
+      <div className="flex w-full gap-[4px] mt-[40px]">
+        <CommonButton variant="secondary" className="border border-primary">
+          응원하기
+        </CommonButton>
+        <CommonButton variant="primary">경고하기</CommonButton>
+      </div>
+    </ModalWrapper>
+  )
+}

--- a/src/mystudymockdata/studyRoomMockData.ts
+++ b/src/mystudymockdata/studyRoomMockData.ts
@@ -1,13 +1,6 @@
-export interface StudyCardData {
-  id: number
-  userProfile: string
-  nickname: string
-  dailyMissions: string[]
-  isMe: boolean
-  isLeader: boolean
-}
+import type { StudyCardDataType } from '@/types/StudyCardDataType'
 
-export const studyRoomUserCardMockData: StudyCardData[] = [
+export const studyRoomUserCardMockData: StudyCardDataType[] = [
   {
     id: 1,
     userProfile: '/images/user1.jpg',

--- a/src/pages/study/StudyRoomPage.tsx
+++ b/src/pages/study/StudyRoomPage.tsx
@@ -1,4 +1,3 @@
-// import { useParams } from 'react-router-dom'
 import Whiteboard from '@/components/study/studyRoomPage/KonvaWhiteBoard'
 import StudyRoomUserCard from '@/components/study/studyRoomPage/StudyRoomUserCard'
 import { studyRoomUserCardMockData } from '@/mystudymockdata/studyRoomMockData'
@@ -11,9 +10,11 @@ import Dropdown from '@/common/DropDown'
 import CommonButton from '@/common/CommonButton'
 import MissionModal from '@/common/MissionModal'
 import { useParams } from 'react-router-dom'
-import defaultPrfileImag from '@/assets/images/default-profile.png'
+import defaultUserImg from '@/assets/images/default-profile.png'
 import StudyRoomMessageInboxModal from '@/components/study/studyRoomPage/StudyRoomMessageInboxModal'
 import StudyRoomSendMessageModal from '@/components/study/studyRoomPage/StudyRoomSendMessageModal'
+import StudyRoomUserProfileModal from '@/components/study/studyRoomPage/StudyRoomUserProfileModal'
+import type { StudyCardDataType } from '@/types/StudyCardDataType'
 
 const reportModalDropdownOption = [
   { label: '부적절한 스터디 내용', value: '1' },
@@ -36,6 +37,10 @@ export default function StudyRoomPage() {
   const [messageSender, setMessageSender] = useState<string | null>(null)
   const { roomId } = useParams()
   const containerRef = useRef<HTMLDivElement>(null)
+  const [isUserProfileModalOpen, setIsUserProfileModalOpen] = useState(false)
+  const [selectedUserProfile, setSelectedUserProfile] =
+    useState<StudyCardDataType | null>(null)
+
   const user = useUserInfo((state) => state.userInfo?.user)
 
   useEffect(() => {
@@ -140,7 +145,7 @@ export default function StudyRoomPage() {
         </div>
         <div className="flex gap-[16px] items-center">
           <img
-            src={user?.profile_image_url ?? defaultPrfileImag}
+            src={user?.profile_image_url ?? defaultUserImg}
             alt="유저프로피이미지"
             className="rounded-full w-[64px]"
           />
@@ -186,10 +191,19 @@ export default function StudyRoomPage() {
               user={user}
               setMessageSender={setMessageSender}
               setIsMessageSendModal={setIsMessageSendModal}
+              setIsUserProfileModalOpen={setIsUserProfileModalOpen}
+              setSelectedUserProfile={setSelectedUserProfile}
             />
           ))}
         </div>
       </div>
+      <StudyRoomUserProfileModal
+        title="프로필 보기"
+        isOpen={isUserProfileModalOpen}
+        onClose={() => setIsUserProfileModalOpen(false)}
+        selectedUserProfile={selectedUserProfile}
+        className="w-[400px] h-[544px] p-[44px]"
+      />
     </div>
   )
 }

--- a/src/types/StudyCardDataType.ts
+++ b/src/types/StudyCardDataType.ts
@@ -1,0 +1,8 @@
+export interface StudyCardDataType {
+  id: number
+  userProfile: string | null
+  nickname: string
+  dailyMissions: string[]
+  isMe: boolean
+  isLeader: boolean
+}


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #120 
- 작업요약 : 스터디룸 프로필 보기 모달 구현

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 유저 이미지를 클릭 시 유저 정보를 받아와서 프로필 보기 모달을 띄워서 보여 줍니다.
- 스터디 카드와 로그인 이미지가 없을 때 기본이미지가 안보이는 문제를 수정 하였습니다.
- 

## 📸 스크린샷 (선택)

<img width="342" height="448" alt="CleanShot 2025-08-09 at 15 34 53" src="https://github.com/user-attachments/assets/b93ee7fe-75ca-4daf-8481-8c795eb625e5" />


## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
