### PR TITLE
✨ feat: 카카오 소셜 로그인 기능 구현

### DIFF
--- a/src/components/Layout/MypageSidebar.tsx
+++ b/src/components/Layout/MypageSidebar.tsx
@@ -1,5 +1,7 @@
 import { NavLink, useLocation } from 'react-router-dom'
 import { useUserInfo } from '@/store/userInfoStore'
+import defaultUserImg from '@/assets/images/default-profile.png'
+import { isKakaoUser } from '@/utils/isKakaoUser'
 
 const MENUITEMS = [
   { path: '/mypage/account', label: '계정 설정' },
@@ -18,33 +20,45 @@ const MENUITEMS = [
 export default function MypageSidebar() {
   const location = useLocation()
   const currentPath = location.pathname
-  const user = useUserInfo((state) => state.userInfo?.user)
+  const userInfo = useUserInfo((state) => state.userInfo)
 
   return (
     <div className="flex flex-col justify-start items-center gap-[45px] w-[272px] ml-[260px] mt-[88px]">
       <div className="flex flex-col items-center gap-[23px] w-full">
-        <div className="w-full flex justify-between gap-[20px]">
+        <div className="w-[272px] flex justify-between gap-[20px]">
           <img
-            src={user?.profile_image_url}
+            src={
+              isKakaoUser(userInfo)
+                ? userInfo.profile_image
+                : (userInfo?.user?.profile_image_url ?? defaultUserImg)
+            }
             alt="유저프로필이미지"
-            className="rounded-full w-[80px]"
+            className="w-[80px] h-[80px] shrink-0 object-cover rounded-full"
           />
-          <div className="flex flex-col justify-center text-left w-full">
-            <div className="text-[20px]">{user?.nickname}</div>
-            <div className="text-[15px] text-text4">{user?.email}</div>
+          <div className="flex flex-col justify-center w-full text-left">
+            <div className="text-[20px]">
+              {isKakaoUser(userInfo)
+                ? userInfo.nickname
+                : (userInfo?.user?.nickname ?? '닉네임')}
+            </div>
+            <div className="text-[15px] text-text4">
+              {isKakaoUser(userInfo)
+                ? userInfo.email
+                : (userInfo?.user?.email ?? '이메일')}
+            </div>
           </div>
         </div>
         <div className="flex w-full justify-around items-center text-[12px] h-[64px] border-primary border-[1px] px-[31px] rounded-[4px]">
           <div className="flex flex-col items-center justify-center">
             <div>총 공부시간</div>
-            <div className="text-text2 font-light">1234 시간</div>
+            <div className="font-light text-text2">1234 시간</div>
           </div>
           <div className="h-[26px] border-[0.5px] border-primary scale-x-50 origin-left">
             {/*세로줄 UI*/}
           </div>
           <div className="flex flex-col items-center justify-center">
             <div>참여한 스터디</div>
-            <div className="text-text2 font-light">99+</div>
+            <div className="font-light text-text2">99+</div>
           </div>
         </div>
       </div>

--- a/src/components/Layout/NavBar.tsx
+++ b/src/components/Layout/NavBar.tsx
@@ -7,8 +7,8 @@ import { useUserInfo } from '@/store/userInfoStore'
 import { MdKeyboardArrowDown, MdKeyboardArrowUp } from 'react-icons/md'
 import NavbarUserInfoDropDown from '@/components/Layout/NavbarUserInfoDropDown'
 import { cn } from '@/utils/cn'
-import { api } from '@/api/mainApi'
-import axios from 'axios'
+// import { api } from '@/api/mainApi'
+// import axios from 'axios'
 
 export default function NavBar() {
   const userInfo = useUserInfo((state) => state.userInfo)
@@ -48,29 +48,33 @@ export default function NavBar() {
     }, 300)
   }
   const logout = async () => {
-    try {
-      const res = await api.post('/api/v1/auth/logout')
-      if (res.status === 200) {
-        useUserInfo.getState().setUserInfo(null)
-        setIsDropdownOpen(false)
-        navigate('/')
-      }
-    } catch (error) {
-      if (axios.isAxiosError(error)) {
-        const status = error.response?.status
-        const detail = error.response?.data?.detail
+    useUserInfo.getState().setUserInfo(null)
+    setIsDropdownOpen(false)
+    navigate('/')
 
-        if (status === 401) {
-          alert(detail || '인증 정보가 유효하지 않습니다. 다시 로그인해주세요.')
-          useUserInfo.getState().setUserInfo(null)
-          navigate('/login')
-        } else {
-          alert('알 수 없는 오류가 발생했습니다.')
-        }
-      } else {
-        alert('네트워크 오류 또는 서버 오류가 발생했습니다.')
-      }
-    }
+    // try {
+    //   const res = await api.post('/api/v1/auth/logout')
+    //   if (res.status === 200) {
+    //     useUserInfo.getState().setUserInfo(null)
+    //     setIsDropdownOpen(false)
+    //     navigate('/')
+    //   }
+    // } catch (error) {
+    //   if (axios.isAxiosError(error)) {
+    //     const status = error.response?.status
+    //     const detail = error.response?.data?.detail
+
+    //     if (status === 401) {
+    //       alert(detail || '인증 정보가 유효하지 않습니다. 다시 로그인해주세요.')
+    //       useUserInfo.getState().setUserInfo(null)
+    //       navigate('/login')
+    //     } else {
+    //       alert('알 수 없는 오류가 발생했습니다.')
+    //     }
+    //   } else {
+    //     alert('네트워크 오류 또는 서버 오류가 발생했습니다.')
+    //   }
+    // }
   }
 
   const navItemClass = 'transition-colors hover:text-[#8349FF] hover:font-bold'
@@ -118,7 +122,11 @@ export default function NavBar() {
                   className="flex items-center cursor-pointer"
                   onClick={() => setIsDropdownOpen((prev) => !prev)}
                 >
-                  <div>{userInfo.user?.nickname}</div>
+                  <div>
+                    {'kakao_id' in userInfo
+                      ? userInfo.nickname
+                      : userInfo.user?.nickname}
+                  </div>
                   {isDropdownOpen ? (
                     <MdKeyboardArrowUp size={20} />
                   ) : (

--- a/src/components/Layout/NavbarUserInfoDropDown.tsx
+++ b/src/components/Layout/NavbarUserInfoDropDown.tsx
@@ -2,31 +2,39 @@ import { useUserInfo } from '@/store/userInfoStore'
 import { Link, useNavigate } from 'react-router-dom'
 import { CiMail } from 'react-icons/ci'
 import CommonButton from '@/common/CommonButton'
+import { isKakaoUser } from '@/utils/isKakaoUser'
 
 export default function NavbarUserInfoDropDown({
   setIsDropdownOpen,
 }: {
   setIsDropdownOpen: React.Dispatch<React.SetStateAction<boolean>>
 }) {
-  const user = useUserInfo((state) => state.userInfo?.user)
+  const userInfo = useUserInfo((state) => state.userInfo)
   const navigate = useNavigate()
   const handleClose = () => {
     setIsDropdownOpen(false)
   }
-
   return (
     <div className="absolute top-10 right-10 text-text bg-white shadow-lg rounded-[10px] w-[264px] h-[204px] z-50 px-[24px] py-[16px]">
-      {user && (
+      {userInfo && (
         <div>
           <div className="flex items-center gap-[8px]">
             <img
-              className="w-[56px] rounded-full"
-              src={user.profile_image_url}
-              alt={`${user.name}의 프로필 이미지`}
+              className="w-[56px] h-[56px] rounded-full shrink-0 object-cover"
+              src={
+                isKakaoUser(userInfo)
+                  ? userInfo.profile_image
+                  : userInfo.user?.profile_image_url
+              }
+              alt={`${isKakaoUser(userInfo) ? userInfo.nickname : userInfo.user?.name}의 프로필 이미지`}
             />
             <div>
               <div className="flex items-center justify-between">
-                <div className="text-[15px]">{user.nickname}</div>
+                <div className="text-[15px]">
+                  {isKakaoUser(userInfo)
+                    ? userInfo.nickname
+                    : userInfo.user?.nickname}
+                </div>
                 <Link
                   to="/mypage/messages/inbox"
                   className="cursor-pointer"
@@ -35,7 +43,9 @@ export default function NavbarUserInfoDropDown({
                   <CiMail />
                 </Link>
               </div>
-              <div className="text-[12px] text-text4">{user.email}</div>
+              <div className="text-[12px] text-text4">
+                {isKakaoUser(userInfo) ? userInfo.email : userInfo.user?.email}
+              </div>
             </div>
           </div>
           <CommonButton

--- a/src/pages/auth/loginPage.tsx
+++ b/src/pages/auth/loginPage.tsx
@@ -58,7 +58,7 @@ export default function LoginPage() {
         code: authorizationCode,
       })
       .then((res: AxiosResponse<KakaoUserData>) => {
-        alert(res)
+        alert(res.data)
         // console.log(res)
       })
   }

--- a/src/pages/auth/loginPage.tsx
+++ b/src/pages/auth/loginPage.tsx
@@ -8,6 +8,7 @@ import { api, mainApi } from '@/api/mainApi'
 import { useUserInfo } from '@/store/userInfoStore'
 import type { AxiosError, AxiosResponse } from 'axios'
 import type { ErrorMessage } from '@/types/errorMessage'
+import { isKakaoUser } from '@/utils/isKakaoUser'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -58,8 +59,10 @@ export default function LoginPage() {
         code: authorizationCode,
       })
       .then((res: AxiosResponse<KakaoUserData>) => {
-        alert(res.data)
-        // console.log(res)
+        if (isKakaoUser(res.data)) {
+          setUserInfo(res.data)
+          navigate('/')
+        }
       })
   }
 

--- a/src/pages/mypage/AccountSettingsPage.tsx
+++ b/src/pages/mypage/AccountSettingsPage.tsx
@@ -4,9 +4,11 @@ import { Link, useNavigate } from 'react-router-dom'
 import { FaComment } from 'react-icons/fa'
 import { MdOutlineArrowForwardIos } from 'react-icons/md'
 import { useUserInfo } from '@/store/userInfoStore'
+import { isKakaoUser } from '@/utils/isKakaoUser'
+import defaultUserImg from '@/assets/images/default-profile.png'
 
 export default function AccountSettingsPage() {
-  const user = useUserInfo((state) => state.userInfo?.user)
+  const userInfo = useUserInfo((state) => state.userInfo)
 
   const navigate = useNavigate()
 
@@ -20,9 +22,13 @@ export default function AccountSettingsPage() {
     <div className="flex flex-col items-center justify-start bg-white mt-[88px] ml-[160px] pb-[20px]">
       <div className="flex flex-col items-center justify-center gap-[72px] self-start">
         <img
-          src={user?.profile_image_url}
+          src={
+            isKakaoUser(userInfo)
+              ? userInfo.profile_image
+              : (userInfo?.user?.profile_image_url ?? defaultUserImg)
+          }
           alt="유저프로필이미지"
-          className="rounded-full w-[96px] self-start"
+          className="rounded-full w-[96px] h-[96px] self-start object-cover"
         />
         <div className="flex flex-col items-center justify-center gap-[32px] w-[400px]">
           <div className="text-[24px] font-semibold self-start">회원정보</div>
@@ -33,14 +39,22 @@ export default function AccountSettingsPage() {
             <div className="flex flex-col pace-y-3 gap-[16px] w-full">
               <InputField
                 className="w-full h-[48px] bg-disabled-fill placeholder:text-text4"
-                placeholder={user?.name}
+                placeholder={
+                  isKakaoUser(userInfo)
+                    ? userInfo.nickname
+                    : (userInfo?.user?.name ?? '닉네임')
+                }
                 type="text"
                 disabled
               />
 
               <InputField
                 className="w-full h-[48px] placeholder:text-text4 bg-disabled-fill"
-                placeholder={user?.email}
+                placeholder={
+                  isKakaoUser(userInfo)
+                    ? userInfo.email
+                    : (userInfo?.user?.email ?? '이메일')
+                }
                 type="email"
                 disabled
               />
@@ -48,7 +62,11 @@ export default function AccountSettingsPage() {
               <div className="flex w-full gap-[4px]">
                 <InputField
                   className="w-[284px] h-[48px] placeholder:text-text4"
-                  placeholder={user?.nickname}
+                  placeholder={
+                    isKakaoUser(userInfo)
+                      ? userInfo.nickname
+                      : (userInfo?.user?.nickname ?? '닉네임')
+                  }
                   type="text"
                 />
 
@@ -63,7 +81,11 @@ export default function AccountSettingsPage() {
               <div className="flex w-full gap-[4px]">
                 <InputField
                   className="w-[284px] h-[48px] placeholder:text-text4 bg-disabled-fill"
-                  placeholder={user?.phone}
+                  placeholder={
+                    isKakaoUser(userInfo)
+                      ? (userInfo.phone ?? '')
+                      : userInfo?.user?.phone
+                  }
                   type="number"
                   disabled
                 />

--- a/src/pages/mypage/StudyPlannerPage.tsx
+++ b/src/pages/mypage/StudyPlannerPage.tsx
@@ -12,6 +12,7 @@ import DropDownCalendar from '@/components/mypage/studyPlannerPage/DropDownCalen
 import { useAttendanceCalendar } from '@/store/useAttendance'
 import { studyOptions } from '@/mystudymockdata/studyOptions'
 import { useUserInfo } from '@/store/userInfoStore'
+import { isKakaoUser } from '@/utils/isKakaoUser'
 
 const goalInProgresses = [
   { goal: '2025년 12월 토익 900점 목표', dDay: 365, progressDay: 256 },
@@ -20,7 +21,7 @@ const goalInProgresses = [
 ]
 
 export default function StudyPlannerPage() {
-  const userName = useUserInfo((state) => state.userInfo?.user?.name)
+  const userInfo = useUserInfo((state) => state.userInfo)
   const [isActive, setIsActive] = useState(false)
   const todos = useTodoStore((state) => state.todos)
   const removeCompletedTodos = useTodoStore(
@@ -49,7 +50,7 @@ export default function StudyPlannerPage() {
   return (
     <div className="w-[768px] mt-[88px] ml-[160px] pb-[20px]">
       <div className="text-[#121212] text-[24px]">
-        {`${userName}님의 스터디플랜`}
+        {`${isKakaoUser(userInfo) ? userInfo.nickname : userInfo?.user?.name}님의 스터디플랜`}
       </div>
       <div className="flex flex-col gap-[16px] mt-[16px]">
         <div className="flex p-[20px] items-center justify-between w-full h-[64px] border-[1px] rounded-[8px] border-[#bdbdbd] font-light">

--- a/src/pages/study/StudyRoomPage.tsx
+++ b/src/pages/study/StudyRoomPage.tsx
@@ -15,6 +15,7 @@ import StudyRoomMessageInboxModal from '@/components/study/studyRoomPage/StudyRo
 import StudyRoomSendMessageModal from '@/components/study/studyRoomPage/StudyRoomSendMessageModal'
 import StudyRoomUserProfileModal from '@/components/study/studyRoomPage/StudyRoomUserProfileModal'
 import type { StudyCardDataType } from '@/types/StudyCardDataType'
+import { isKakaoUser } from '@/utils/isKakaoUser'
 
 const reportModalDropdownOption = [
   { label: '부적절한 스터디 내용', value: '1' },
@@ -28,7 +29,7 @@ const reportModalDropdownOption = [
 
 export default function StudyRoomPage() {
   const [isOpenTitleMenuModal, setIsOpenTitleMenuModal] = useState(false)
-  const [isReprotModalOpen, setReportModalOpen] = useState(false)
+  const [isReportModalOpen, setReportModalOpen] = useState(false)
   const [isDailyModalOpen, setIsDailyModalOpen] = useState(false)
   const [isMessageInboxModalOpen, setIsMessageInboxModalOpen] = useState(false)
   const [selectReportModalDropdownOption, setSelectReportModalDropdownOption] =
@@ -41,7 +42,7 @@ export default function StudyRoomPage() {
   const [selectedUserProfile, setSelectedUserProfile] =
     useState<StudyCardDataType | null>(null)
 
-  const user = useUserInfo((state) => state.userInfo?.user)
+  const userInfo = useUserInfo((state) => state.userInfo)
 
   useEffect(() => {
     if (roomId) {
@@ -75,7 +76,7 @@ export default function StudyRoomPage() {
             )}
             <CommonModal
               title="스터디 신고"
-              isOpen={isReprotModalOpen}
+              isOpen={isReportModalOpen}
               onClose={() => setReportModalOpen(false)}
               className="w-[560px] h-[598px] p-[40px]"
             >
@@ -121,7 +122,7 @@ export default function StudyRoomPage() {
                 onClose={() => setIsDailyModalOpen(false)}
                 title="데일리 미션"
                 subtitle={
-                  <p className="whitespace-pre-line text-sm text-text4 text-center">
+                  <p className="text-sm text-center whitespace-pre-line text-text4">
                     내가 오늘 꼭 달성하고 싶은 목표를 설정해주세요!
                     {'\n'}최대 5개까지 설정할 수 있습니다.
                   </p>
@@ -145,12 +146,20 @@ export default function StudyRoomPage() {
         </div>
         <div className="flex gap-[16px] items-center">
           <img
-            src={user?.profile_image_url ?? defaultUserImg}
+            src={
+              isKakaoUser(userInfo)
+                ? userInfo.profile_image
+                : (userInfo?.user?.profile_image_url ?? defaultUserImg)
+            }
             alt="유저프로피이미지"
-            className="rounded-full w-[64px]"
+            className="rounded-full w-[64px] h-[64px] shrink-0 object-cover"
           />
           <div className="flex gap-[8px] items-center">
-            <div className="text-[18px] text-text1">{user?.nickname}</div>
+            <div className="text-[18px] text-text1">
+              {isKakaoUser(userInfo)
+                ? userInfo.nickname
+                : (userInfo?.user?.nickname ?? '닉네임')}
+            </div>
             <CiMail
               size={20}
               className="text-[#bdbdbd] cursor-pointer"

--- a/src/store/userInfoStore.ts
+++ b/src/store/userInfoStore.ts
@@ -1,8 +1,6 @@
 import { create } from 'zustand'
-import type { KakaoUserData, UserDataWithToken } from '@/types/userData'
+import type { UserInfo } from '@/types/userData'
 import { persist } from 'zustand/middleware'
-
-type UserInfo = UserDataWithToken | KakaoUserData | null
 
 type UserInfoState = {
   userInfo: UserInfo

--- a/src/types/userData.ts
+++ b/src/types/userData.ts
@@ -20,4 +20,7 @@ export interface KakaoUserData extends UserDataWithToken {
   nickname: string
   email: string
   profile_image: string
+  phone: string | null
 }
+
+export type UserInfo = UserDataWithToken | KakaoUserData | null

--- a/src/utils/isKakaoUser.ts
+++ b/src/utils/isKakaoUser.ts
@@ -1,0 +1,8 @@
+import type { KakaoUserData, UserInfo } from '@/types/userData'
+
+// 타입 가드 함수
+export function isKakaoUser(userInfo: UserInfo): userInfo is KakaoUserData {
+  return (
+    userInfo !== null && typeof userInfo === 'object' && 'kakao_id' in userInfo
+  )
+}


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #129
- 작업요약 : 카카오 소셜 로그인 기능 구현

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 로그인 페이지에서 카카오 로그인버튼 클릭 시 카카오 로그인 할 수 있습니다.
- 클라이언트에서 리다이렉션 페이지를 받아서 인가코드를 추출하여 서버에 전달하면 서버에서 카카오로부터 유저정보를
   받아와 클라이언트에 보내 줍니다.

< 카카오 로그인 프로세스 >

<img width="895" height="617" alt="CleanShot 2025-08-14 at 14 30 45" src="https://github.com/user-attachments/assets/35a8f203-6a83-44b5-ac79-c1a9c789b985" />


## 📸 스크린샷 (선택)


<메인 페이지 Dropdown 메뉴>
<img width="400" alt="CleanShot 2025-08-14 at 14 22 45" src="https://github.com/user-attachments/assets/7678e952-e73f-4e63-ac78-c9185d45d417" />

<스터디 플랜 화면>
<img width="400" alt="CleanShot 2025-08-14 at 14 23 52" src="https://github.com/user-attachments/assets/faecd8be-5bac-4a7a-8e04-8210dab3b152" />

<회원 정보 페이지 화면>
<img width="400" height="712" alt="CleanShot 2025-08-14 at 14 25 42" src="https://github.com/user-attachments/assets/bff165ad-1b3e-4ca0-bc46-c2a01393d35f" />

<스터디룸 화면>
<img width="600" alt="CleanShot 2025-08-14 at 14 26 51" src="https://github.com/user-attachments/assets/63ac3037-a46c-463f-af61-e8a9b074ffbe" />


<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
