### PR TITLE
🐛 fix: 원 스케치 원점이 좌측 상단으로 고정되는 문제 수정

### DIFF
--- a/src/hooks/useDrawingToolHook.ts
+++ b/src/hooks/useDrawingToolHook.ts
@@ -40,12 +40,5 @@ export function useDrawingTool(
       default:
         return null
     }
-  }, [
-    toolName,
-    color,
-    sharedState.circles,
-    sharedState.setCircles,
-    sharedState.setLines,
-    shouldFillCircle,
-  ])
+  }, [toolName, color])
 }


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #148 
- 작업요약 : 스터디룸 원 스케치 오류 수정

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- useDrawingTool 의 반환값 삭제
- circle 스케치 시 원점이 좌측 상단에서 마우스 다운 하는 부분으로 수정

## 📸 스크린샷 (선택)
 
<수정 전 : 원점이 좌측 상단으로 고정됨>
<img width="400" alt="CleanShot 2025-08-18 at 23 22 31" src="https://github.com/user-attachments/assets/9a7b393b-a80f-45d7-bd84-3988387927e4" />

<수정 후 : 원점이 마우스 다운 부분으로 적용>
<img width="400" alt="CleanShot 2025-08-18 at 23 36 09" src="https://github.com/user-attachments/assets/50e69cf2-0adf-43f5-8e1b-51f5c3cc2082" />
 

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
