### PR TITLE
✨ feat: 스터디룸 웹소켓 연결 실시간 스케치 공유 기능 추가

### DIFF
--- a/src/api/soket.ts
+++ b/src/api/soket.ts
@@ -1,0 +1,44 @@
+let socket: WebSocket | null = null
+
+// study_id 기반으로 소켓 초기화
+export const initSocket = (studyId: string) => {
+  // WebSocket 객체를 생성합니다.
+  socket = new WebSocket(`wss://storbit.o-r.kr/ws/study/${studyId}/`)
+
+  socket.onopen = () => {
+    // console.log('WebSocket 연결 성공')
+  }
+
+  socket.onclose = () => {
+    // console.log('WebSocket 연결 해제')
+  }
+
+  socket.onerror = (_error) => {
+    // console.error('WebSocket 오류 발생:', error)
+  }
+
+  // 메시지 수신 핸들러 추가
+  socket.onmessage = (_event) => {
+    // const data = JSON.parse(event.data)
+    // TODO: 서버에서 받은 데이터(다른 유저의 그리기 정보)를 처리하는 로직 추가
+    // 예: 다른 유저가 그린 선이나 원을 화면에 렌더링
+  }
+
+  return socket
+}
+
+// 소켓 가져오기
+export const getSocket = () => {
+  if (!socket || socket.readyState !== WebSocket.OPEN) {
+    throw new Error('Socket not initialized or not connected')
+  }
+  return socket
+}
+
+// 소켓 연결 해제
+export const disconnectSocket = () => {
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    socket.close()
+    socket = null
+  }
+}

--- a/src/components/study/studyRoomPage/CircleTool.tsx
+++ b/src/components/study/studyRoomPage/CircleTool.tsx
@@ -1,9 +1,8 @@
-// tools/CircleTool.ts
 import React from 'react'
 import type { DrawingTool } from '@/types/drawingTool'
 import type { KonvaEventObject } from 'konva/lib/Node'
-// import { Circle as KonvaCircle } from 'react-konva'
 import type { Circle } from '@/types/circle'
+import { getSocket } from '@/api/soket'
 
 export class CircleTool implements DrawingTool {
   private isDrawing = false
@@ -77,6 +76,12 @@ export class CircleTool implements DrawingTool {
 
     this.circles.push(finalCircle)
     this.setCircles([...this.circles])
+    const socket = getSocket()
+    const message = {
+      type: 'draw:circle', // 서버에서 구분할 타입
+      data: finalCircle,
+    }
+    socket.send(JSON.stringify(message))
   }
 
   setColor(color: string) {

--- a/src/components/study/studyRoomPage/KonvaWhiteBoard.tsx
+++ b/src/components/study/studyRoomPage/KonvaWhiteBoard.tsx
@@ -1,16 +1,19 @@
 // Whiteboard.tsx
+import { disconnectSocket, initSocket } from '@/api/soket'
 import StudyRoomToolbox from '@/components/study/studyRoomPage/StudyRoomToolbox'
 import { useDrawingTool } from '@/hooks/useDrawingToolHook'
 import type { Circle as CircleType } from '@/types/circle'
 import type { ColoredLine } from '@/types/point'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Stage, Layer, Line, Circle } from 'react-konva'
+import { useParams } from 'react-router-dom'
 
 export default function Whiteboard({
   containerRef,
 }: {
   containerRef: React.RefObject<HTMLDivElement | null>
 }) {
+  const { roomId: studyId } = useParams()
   const [toolName, setToolName] = useState<'pen' | 'circle' | 'fillCircle'>(
     'pen'
   )
@@ -27,6 +30,35 @@ export default function Whiteboard({
 
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 })
 
+  const socketRef = useRef<WebSocket | null>(null)
+
+  useEffect(() => {
+    if (!studyId) return
+    const socket = initSocket(studyId)
+    socketRef.current = socket
+
+    // 서버에서 메시지를 받으면 실행될 핸들러
+    socket.onmessage = (event) => {
+      try {
+        const { type, data } = JSON.parse(event.data)
+        // console.log(data)
+        if (type === 'draw:pen') {
+          setLines((prev) => [...prev, data])
+        } else if (type === 'draw:circle') {
+          setCircles((prev) => [...prev, data])
+        }
+      } catch (_error) {
+        void 0
+        // console.error('Failed to parse message from server:', e)
+      }
+    }
+
+    return () => {
+      disconnectSocket()
+      socketRef.current = null
+    }
+  }, [studyId])
+  // console.log(lines)
   //화이트보드 사이즈 부모 사이즈 기준으로 적용
   useEffect(() => {
     if (!containerRef.current) return

--- a/src/components/study/studyRoomPage/PenTool.tsx
+++ b/src/components/study/studyRoomPage/PenTool.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import type { DrawingTool } from '@/types/drawingTool'
 import type { KonvaEventObject } from 'konva/lib/Node'
 import type { ColoredLine } from '@/types/point'
+import { getSocket } from '@/api/soket'
 
 export class PenTool implements DrawingTool {
   private isDrawing = false
@@ -62,6 +63,17 @@ export class PenTool implements DrawingTool {
 
   onMouseUp() {
     this.isDrawing = false
+    const lastLine = this.lines[this.lines.length - 1]
+    const socket = getSocket()
+
+    // JSON 형태로 데이터를 변환하여 서버로 전송
+    const message = {
+      type: 'draw:pen', // 서버에서 구분할 타입
+      data: lastLine,
+    }
+
+    // console.log(message)
+    socket.send(JSON.stringify(message))
   }
 
   setColor(color: string) {

--- a/src/components/study/studyRoomPage/StudyRoomToolbox.tsx
+++ b/src/components/study/studyRoomPage/StudyRoomToolbox.tsx
@@ -1,4 +1,4 @@
-import { TbTextResize } from 'react-icons/tb'
+// import { TbTextResize } from 'react-icons/tb'
 import { SlPencil } from 'react-icons/sl'
 import { LuCircle } from 'react-icons/lu'
 import { FaCircle } from 'react-icons/fa'
@@ -19,8 +19,8 @@ export default function StudyRoomToolbox({
   setShouldFillCircle,
 }: StudyRoomToolboxProps) {
   return (
-    <div className="flex items-center gap-[10px] px-[22px] py-[12px] ml-[10px] absolute bottom-[40px] left-1/2 -translate-x-1/2 h-[48px] w-[150px] z-20 bg-white shadow-[1px_1px_8px_rgba(0,0,0,0.25)] rounded-[8px]">
-      <TbTextResize size={30} />
+    <div className="flex items-center justify-center gap-[10px] px-[22px] py-[12px] ml-[10px] absolute bottom-[40px] left-1/2 -translate-x-1/2 h-[48px] w-[200px] z-20 bg-white shadow-[1px_1px_8px_rgba(0,0,0,0.25)] rounded-[8px]">
+      {/* <TbTextResize size={30} /> */}
       <SlPencil
         size={25}
         className="cursor-pointer"
@@ -46,7 +46,7 @@ export default function StudyRoomToolbox({
         type="color"
         value={color}
         onChange={(e) => setColor(e.target.value)}
-        className="w-[20px]"
+        className="w-[30px]"
       />
     </div>
   )


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #151
- 작업요약 : Konva 화이트보드에 실시간 동기화 기능 추가를 위한 웹소켓 연결 로직 구현

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- `soket.ts`: `WebSocket` 객체를 사용
- `penTool.ts` & `circleTool.ts`:  `socket.send()`로 JSON 데이터를 전송
- `konvaWhiteBoard.tsx`: 서버로부터 받은 실시간 그리기 데이터를 `onmessage` 핸들러에서 처리하여 화면에 반영하는 로직 추가.
- `useDrawingTool.ts`: `useMemo` 훅의 의존성 배열에 `color`를 추가하여 툴의 색상 변경이 즉시 반영되도록 수정.

## 📸 스크린샷 (선택)

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
