### PR TITLE
🐛 fix: 드로잉 이벤트에 유저 식별자 추가 및 멀티 유저 선 충돌 문제 해결 + 로그아웃 시 오류발생시에도 유저정보 로컬삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,629 @@
-# React + TypeScript + Vite
+```
+storbit
+├─ .husky                                           허스키 설정 폴더
+│  ├─ commit-msg                                    커밋 컨벤션 규칙
+│  └─ pre-commit                                    커밋전 lint 및 prettier 검사
+├─ .prettierrc                                      prettier 규칙
+├─ README.md
+├─ eslint.config.js                                 lint 설정
+├─ index.html
+├─ package-lock.json
+├─ package.json
+├─ src
+│  ├─ App.css                                       tailwindcss 스타일링 전역 변수 설정
+│  ├─ App.tsx
+│  ├─ admin                                         admin 관련 컴포넌트 (이벤트 페이지 생성/업데이트)
+│  ├─ api                                           axios 인스턴스 , msw, 웹소켓 통신
+│  │  ├─ mainApi.ts                                 서버 / msw api 연결
+│  │  ├─ mswMock                                    msw 모킹용 api 폴더
+│  │  │  ├─ MockData.ts                             msw Mock 데이터 저장
+│  │  │  ├─ browser.ts                              msw handler 함수를 모아서 전달
+│  │  │  └─ handlers                                msw handler 함수 폴더
+│  │  │     ├─ authHandlers.ts                      msw 로그인/로그아웃/회원가입
+│  │  │     ├─ myStudiesHandlers.ts                 msw 나의 스터디
+│  │  │     └─ studyMakeHandlers.ts                 msw 스터디 만들기
+│  │  ├─ myApplications.ts
+│  │  └─ socket.ts
+│  ├─ assets
+│  ├─ common
+│  ├─ components
+│  │  ├─ Category
+│  │  ├─ Layout
+│  │  ├─ Main
+│  │  ├─ auth
+│  │  ├─ event
+│  │  ├─ mypage
+│  │  │  ├─ messageInboxPage
+│  │  │  ├─ messageSentboxPage
+│  │  │  └─ studyPlannerPage
+│  │  ├─ search
+│  │  └─ study
+│  │     └─ studyRoomPage
+│  ├─ constants
+│  ├─ data
+│  ├─ hooks
+│  ├─ index.css
+│  ├─ main.tsx
+│  ├─ mystudymockdata
+│  ├─ pages
+│  │  ├─ Layout
+│  │  ├─ NotFound.tsx
+│  │  ├─ auth
+│  │  ├─ category
+│  │  ├─ contact
+│  │  ├─ event
+│  │  ├─ mypage
+│  │  ├─ mystudy
+│  │  ├─ privacy
+│  │  ├─ search
+│  │  ├─ study
+│  │  └─ terms
+│  ├─ schemas
+│  ├─ store
+│  ├─ types
+│  ├─ utils
+├─ tsconfig.app.json
+├─ tsconfig.json
+├─ tsconfig.node.json
+└─ vite.config.ts
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+```
+storbit
+├─ .husky
+│  ├─ _
+│  │  ├─ applypatch-msg
+│  │  ├─ commit-msg
+│  │  ├─ h
+│  │  ├─ husky.sh
+│  │  ├─ post-applypatch
+│  │  ├─ post-checkout
+│  │  ├─ post-commit
+│  │  ├─ post-merge
+│  │  ├─ post-rewrite
+│  │  ├─ pre-applypatch
+│  │  ├─ pre-auto-gc
+│  │  ├─ pre-commit
+│  │  ├─ pre-merge-commit
+│  │  ├─ pre-push
+│  │  ├─ pre-rebase
+│  │  └─ prepare-commit-msg
+│  ├─ commit-msg
+│  └─ pre-commit
+├─ .prettierrc
+├─ README.md
+├─ eslint.config.js
+├─ index.html
+├─ package-lock.json
+├─ package.json
+├─ public
+│  ├─ assets
+│  │  ├─ event
+│  │  │  ├─ detail1.png
+│  │  │  ├─ detail2.png
+│  │  │  └─ thumb.png
+│  │  ├─ font
+│  │  │  └─ PretendardVariable.woff2
+│  │  ├─ icons
+│  │  │  ├─ CheckIcon.png
+│  │  │  ├─ MainLogo.png
+│  │  │  └─ StudyStartIcon.png
+│  │  └─ mockdataimage
+│  │     ├─ profile.png
+│  │     └─ requestedStudy.png
+│  ├─ mockServiceWorker.js
+│  └─ vite.svg
+├─ qodana.yaml
+├─ src
+│  ├─ App.css
+│  ├─ App.tsx
+│  ├─ admin
+│  │  └─ events
+│  │     ├─ CreateEvent.tsx
+│  │     └─ UpdateEvent.tsx
+│  ├─ api
+│  │  ├─ mainApi.ts
+│  │  ├─ mswMock
+│  │  │  ├─ MockData.ts
+│  │  │  ├─ browser.ts
+│  │  │  └─ handlers
+│  │  │     ├─ authHandlers.ts
+│  │  │     ├─ myStudiesHandlers.ts
+│  │  │     └─ studyMakeHandlers.ts
+│  │  └─ myApplications.ts
+│  ├─ assets
+│  │  ├─ font
+│  │  │  └─ PretendardVariable.woff2
+│  │  ├─ icons
+│  │  │  ├─ CheckIcon.png
+│  │  │  ├─ MainLogo.png
+│  │  │  └─ StudyStartIcon.png
+│  │  └─ images
+│  │     ├─ achievement-banner.png
+│  │     ├─ admin-logo.png
+│  │     ├─ beginner-banner.png
+│  │     ├─ best-banner.png
+│  │     ├─ custom-banner.png
+│  │     ├─ dawn-banner.png
+│  │     ├─ deadline-banner.png
+│  │     ├─ default-profile.png
+│  │     ├─ default-thumbnail.png
+│  │     ├─ favicon-32x32.png
+│  │     ├─ hot-banner.png
+│  │     ├─ logo-w.png
+│  │     ├─ main01.png
+│  │     └─ weekend-banner.png
+│  ├─ common
+│  │  ├─ ArrowNavigation.tsx
+│  │  ├─ CommonButton.tsx
+│  │  ├─ CommonModal.tsx
+│  │  ├─ ConfirmModal
+│  │  │  └─ ApplicationCompleted.tsx
+│  │  ├─ ConfirmModal.tsx
+│  │  ├─ DropDown.tsx
+│  │  ├─ InputField.tsx
+│  │  ├─ LeaderDelegateModal.tsx
+│  │  ├─ LeaderMissionModal.tsx
+│  │  ├─ MemberKickModal.tsx
+│  │  ├─ MemberStatusModal.tsx
+│  │  ├─ MissionModal.tsx
+│  │  ├─ ModalWrapper.tsx
+│  │  ├─ RecruitStatusModal.tsx
+│  │  ├─ ScrollToTop.tsx
+│  │  ├─ SortTab.tsx
+│  │  ├─ StudyApplyModal.tsx
+│  │  ├─ StudyCard.tsx
+│  │  ├─ StudyDismantle.tsx
+│  │  ├─ StudyLeaveModal.tsx
+│  │  ├─ SwitchToggle.tsx
+│  │  ├─ ToastMessage.tsx
+│  │  ├─ TransientModal.tsx
+│  │  ├─ mystudy
+│  │  │  └─ MyStudyCard.tsx
+│  │  └─ tag
+│  │     ├─ EventTag.tsx
+│  │     └─ StudyTag.tsx
+│  ├─ components
+│  │  ├─ Category
+│  │  │  ├─ CategoryBanner.tsx
+│  │  │  └─ CategorySectionSlider.tsx
+│  │  ├─ Layout
+│  │  │  ├─ AdminNavBar.tsx
+│  │  │  ├─ CategoryMenu.tsx
+│  │  │  ├─ Footer.tsx
+│  │  │  ├─ MyStudySidebar.tsx
+│  │  │  ├─ MypageSidebar.tsx
+│  │  │  ├─ NavBar.tsx
+│  │  │  └─ NavbarUserInfoDropDown.tsx
+│  │  ├─ Main
+│  │  │  ├─ CategoryShortcutTabs.tsx
+│  │  │  ├─ JoinedStudySection.tsx
+│  │  │  └─ MainBanner.tsx
+│  │  ├─ auth
+│  │  ├─ event
+│  │  │  ├─ EventCard.tsx
+│  │  │  └─ EventForm.tsx
+│  │  ├─ mypage
+│  │  │  ├─ messageInboxPage
+│  │  │  │  ├─ InboxMessageDetail.tsx
+│  │  │  │  └─ InboxMessageList.tsx
+│  │  │  ├─ messageSentboxPage
+│  │  │  │  ├─ SentboxMessageDetail.tsx
+│  │  │  │  └─ SentboxMessageList.tsx
+│  │  │  └─ studyPlannerPage
+│  │  │     ├─ AttendanceCalendar.css
+│  │  │     ├─ AttendanceCalendar.tsx
+│  │  │     ├─ DropDownCalendar.tsx
+│  │  │     ├─ ProgressBar.tsx
+│  │  │     ├─ WriteTodo.tsx
+│  │  │     └─ todo.tsx
+│  │  ├─ search
+│  │  │  ├─ SearchEmptyState.tsx
+│  │  │  └─ SearchResultList.tsx
+│  │  └─ study
+│  │     └─ studyRoomPage
+│  │        ├─ CircleTool.tsx
+│  │        ├─ KonvaWhiteBoard.tsx
+│  │        ├─ PenTool.tsx
+│  │        ├─ StudyRoomInboxMessage.tsx
+│  │        ├─ StudyRoomMessageInboxModal.tsx
+│  │        ├─ StudyRoomSendMessageModal.tsx
+│  │        ├─ StudyRoomToolbox.tsx
+│  │        ├─ StudyRoomUserCard.tsx
+│  │        └─ StudyRoomUserProfileModal.tsx
+│  ├─ constants
+│  │  ├─ levelOptions.ts
+│  │  └─ studyOptions.ts
+│  ├─ data
+│  │  ├─ categoryData.ts
+│  │  ├─ dummyData.ts
+│  │  ├─ eventMockData.ts
+│  │  ├─ mockData.ts
+│  │  ├─ recruitStatusData.ts
+│  │  └─ recruitStatusMock.json
+│  ├─ hooks
+│  │  ├─ useClickOutside.ts
+│  │  ├─ useDrawingToolHook.ts
+│  │  └─ useLogin.ts
+│  ├─ index.css
+│  ├─ main.tsx
+│  ├─ mystudymockdata
+│  │  ├─ inboxMessageData.ts
+│  │  ├─ mockStudyData.json
+│  │  ├─ sentboxMessageData.ts
+│  │  ├─ studyCreateOptionsData.ts
+│  │  ├─ studyOptions.ts
+│  │  └─ studyRoomMockData.ts
+│  ├─ pages
+│  │  ├─ Layout
+│  │  │  ├─ Layout.tsx
+│  │  │  ├─ MessageLayout.tsx
+│  │  │  ├─ MyStudyLayout.tsx
+│  │  │  ├─ MypageLayout.tsx
+│  │  │  └─ ProtectedRoute.tsx
+│  │  ├─ NotFound.tsx
+│  │  ├─ auth
+│  │  │  ├─ AccountDeletePage.tsx
+│  │  │  ├─ FindEmailPage.tsx
+│  │  │  ├─ FindEmailSuccessPage.tsx
+│  │  │  ├─ FindPasswordPage.tsx
+│  │  │  ├─ MainPage.tsx
+│  │  │  ├─ RequireAdmin.tsx
+│  │  │  ├─ ResetPasswordPage.tsx
+│  │  │  ├─ ResetPasswordSuccessPage.tsx
+│  │  │  ├─ SignupPage.tsx
+│  │  │  ├─ SignupTermsPage.tsx
+│  │  │  └─ loginPage.tsx
+│  │  ├─ category
+│  │  │  ├─ CategoryDetailPage.tsx
+│  │  │  ├─ CategoryPage.tsx
+│  │  │  ├─ CategoryShortcutPage.tsx
+│  │  │  ├─ CustomRecommendPage.tsx
+│  │  │  └─ SideCategoryMenu.tsx
+│  │  ├─ contact
+│  │  │  └─ ContactPage.tsx
+│  │  ├─ event
+│  │  │  ├─ EventDetailPage.tsx
+│  │  │  ├─ EventListPage.tsx
+│  │  │  └─ EventMainPage.tsx
+│  │  ├─ mypage
+│  │  │  ├─ AccountSettingsPage.tsx
+│  │  │  ├─ MessageInboxPage.tsx
+│  │  │  ├─ MessageSentPage.tsx
+│  │  │  ├─ MessageWritePage.tsx
+│  │  │  └─ StudyPlannerPage.tsx
+│  │  ├─ mystudy
+│  │  │  ├─ MyStudyAppliedPage.tsx
+│  │  │  ├─ MyStudyCreatedPage.tsx
+│  │  │  ├─ MyStudyFavoritesPage.tsx
+│  │  │  ├─ MyStudyJoinedPage.tsx
+│  │  │  └─ StudyManagePage.tsx
+│  │  ├─ privacy
+│  │  │  └─ PrivacyPolicyPage.tsx
+│  │  ├─ search
+│  │  │  └─ SearchResultPage.tsx
+│  │  ├─ study
+│  │  │  ├─ StudyCategoryPage.tsx
+│  │  │  ├─ StudyCreatePage.tsx
+│  │  │  ├─ StudyCreateSuccessPage.tsx
+│  │  │  └─ StudyRoomPage.tsx
+│  │  └─ terms
+│  │     └─ TermsOfServicePage.tsx
+│  ├─ schemas
+│  │  └─ signupFormSchema.ts
+│  ├─ store
+│  │  ├─ useAttendance.ts
+│  │  ├─ useDismantledStudiesStore.ts
+│  │  ├─ useInboxMessageStore.ts
+│  │  ├─ useSentboxMessageStore.ts
+│  │  ├─ useTodoStore.ts
+│  │  └─ userInfoStore.ts
+│  ├─ types
+│  │  ├─ Applicant.ts
+│  │  ├─ RecruitApplicant.ts
+│  │  ├─ StudyCardDataType.ts
+│  │  ├─ circle.ts
+│  │  ├─ drawingTool.ts
+│  │  ├─ errorMessage.ts
+│  │  ├─ event.ts
+│  │  ├─ message.ts
+│  │  ├─ point.ts
+│  │  ├─ signupForm.ts
+│  │  ├─ study.ts
+│  │  ├─ studyCreateType.ts
+│  │  ├─ todo.ts
+│  │  └─ userData.ts
+│  ├─ utils
+│  │  ├─ cn.ts
+│  │  ├─ generateYearMonthOptions.ts
+│  │  ├─ getAccessToken.ts
+│  │  ├─ isAdmin.ts
+│  │  ├─ isKakaoUser.ts
+│  │  └─ toCustomDate.ts
+│  └─ vite-env.d.ts
+├─ tsconfig.app.json
+├─ tsconfig.json
+├─ tsconfig.node.json
+└─ vite.config.ts
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+```
+```
+storbit
+├─ .husky
+│  ├─ _
+│  │  ├─ applypatch-msg
+│  │  ├─ commit-msg
+│  │  ├─ h
+│  │  ├─ husky.sh
+│  │  ├─ post-applypatch
+│  │  ├─ post-checkout
+│  │  ├─ post-commit
+│  │  ├─ post-merge
+│  │  ├─ post-rewrite
+│  │  ├─ pre-applypatch
+│  │  ├─ pre-auto-gc
+│  │  ├─ pre-commit
+│  │  ├─ pre-merge-commit
+│  │  ├─ pre-push
+│  │  ├─ pre-rebase
+│  │  └─ prepare-commit-msg
+│  ├─ commit-msg
+│  └─ pre-commit
+├─ .prettierrc
+├─ README.md
+├─ eslint.config.js
+├─ index.html
+├─ package-lock.json
+├─ package.json
+├─ public
+│  ├─ assets
+│  │  ├─ event
+│  │  │  ├─ detail1.png
+│  │  │  ├─ detail2.png
+│  │  │  └─ thumb.png
+│  │  ├─ font
+│  │  │  └─ PretendardVariable.woff2
+│  │  ├─ icons
+│  │  │  ├─ CheckIcon.png
+│  │  │  ├─ MainLogo.png
+│  │  │  └─ StudyStartIcon.png
+│  │  └─ mockdataimage
+│  │     ├─ profile.png
+│  │     └─ requestedStudy.png
+│  ├─ mockServiceWorker.js
+│  └─ vite.svg
+├─ qodana.yaml
+├─ src
+│  ├─ App.css
+│  ├─ App.tsx
+│  ├─ admin
+│  │  └─ events
+│  │     ├─ CreateEvent.tsx
+│  │     └─ UpdateEvent.tsx
+│  ├─ api
+│  │  ├─ mainApi.ts
+│  │  ├─ mswMock
+│  │  │  ├─ MockData.ts
+│  │  │  ├─ browser.ts
+│  │  │  └─ handlers
+│  │  │     ├─ authHandlers.ts
+│  │  │     ├─ myStudiesHandlers.ts
+│  │  │     └─ studyMakeHandlers.ts
+│  │  └─ myApplications.ts
+│  ├─ assets
+│  │  ├─ font
+│  │  │  └─ PretendardVariable.woff2
+│  │  ├─ icons
+│  │  │  ├─ CheckIcon.png
+│  │  │  ├─ MainLogo.png
+│  │  │  └─ StudyStartIcon.png
+│  │  └─ images
+│  │     ├─ achievement-banner.png
+│  │     ├─ admin-logo.png
+│  │     ├─ beginner-banner.png
+│  │     ├─ best-banner.png
+│  │     ├─ custom-banner.png
+│  │     ├─ dawn-banner.png
+│  │     ├─ deadline-banner.png
+│  │     ├─ default-profile.png
+│  │     ├─ default-thumbnail.png
+│  │     ├─ favicon-32x32.png
+│  │     ├─ hot-banner.png
+│  │     ├─ logo-w.png
+│  │     ├─ main01.png
+│  │     └─ weekend-banner.png
+│  ├─ common
+│  │  ├─ ArrowNavigation.tsx
+│  │  ├─ CommonButton.tsx
+│  │  ├─ CommonModal.tsx
+│  │  ├─ ConfirmModal
+│  │  │  └─ ApplicationCompleted.tsx
+│  │  ├─ ConfirmModal.tsx
+│  │  ├─ DropDown.tsx
+│  │  ├─ InputField.tsx
+│  │  ├─ LeaderDelegateModal.tsx
+│  │  ├─ LeaderMissionModal.tsx
+│  │  ├─ MemberKickModal.tsx
+│  │  ├─ MemberStatusModal.tsx
+│  │  ├─ MissionModal.tsx
+│  │  ├─ ModalWrapper.tsx
+│  │  ├─ RecruitStatusModal.tsx
+│  │  ├─ ScrollToTop.tsx
+│  │  ├─ SortTab.tsx
+│  │  ├─ StudyApplyModal.tsx
+│  │  ├─ StudyCard.tsx
+│  │  ├─ StudyDismantle.tsx
+│  │  ├─ StudyLeaveModal.tsx
+│  │  ├─ SwitchToggle.tsx
+│  │  ├─ ToastMessage.tsx
+│  │  ├─ TransientModal.tsx
+│  │  ├─ mystudy
+│  │  │  └─ MyStudyCard.tsx
+│  │  └─ tag
+│  │     ├─ EventTag.tsx
+│  │     └─ StudyTag.tsx
+│  ├─ components
+│  │  ├─ Category
+│  │  │  ├─ CategoryBanner.tsx
+│  │  │  └─ CategorySectionSlider.tsx
+│  │  ├─ Layout
+│  │  │  ├─ AdminNavBar.tsx
+│  │  │  ├─ CategoryMenu.tsx
+│  │  │  ├─ Footer.tsx
+│  │  │  ├─ MyStudySidebar.tsx
+│  │  │  ├─ MypageSidebar.tsx
+│  │  │  ├─ NavBar.tsx
+│  │  │  └─ NavbarUserInfoDropDown.tsx
+│  │  ├─ Main
+│  │  │  ├─ CategoryShortcutTabs.tsx
+│  │  │  ├─ JoinedStudySection.tsx
+│  │  │  └─ MainBanner.tsx
+│  │  ├─ auth
+│  │  ├─ event
+│  │  │  ├─ EventCard.tsx
+│  │  │  └─ EventForm.tsx
+│  │  ├─ mypage
+│  │  │  ├─ messageInboxPage
+│  │  │  │  ├─ InboxMessageDetail.tsx
+│  │  │  │  └─ InboxMessageList.tsx
+│  │  │  ├─ messageSentboxPage
+│  │  │  │  ├─ SentboxMessageDetail.tsx
+│  │  │  │  └─ SentboxMessageList.tsx
+│  │  │  └─ studyPlannerPage
+│  │  │     ├─ AttendanceCalendar.css
+│  │  │     ├─ AttendanceCalendar.tsx
+│  │  │     ├─ DropDownCalendar.tsx
+│  │  │     ├─ ProgressBar.tsx
+│  │  │     ├─ WriteTodo.tsx
+│  │  │     └─ todo.tsx
+│  │  ├─ search
+│  │  │  ├─ SearchEmptyState.tsx
+│  │  │  └─ SearchResultList.tsx
+│  │  └─ study
+│  │     └─ studyRoomPage
+│  │        ├─ CircleTool.tsx
+│  │        ├─ KonvaWhiteBoard.tsx
+│  │        ├─ PenTool.tsx
+│  │        ├─ StudyRoomInboxMessage.tsx
+│  │        ├─ StudyRoomMessageInboxModal.tsx
+│  │        ├─ StudyRoomSendMessageModal.tsx
+│  │        ├─ StudyRoomToolbox.tsx
+│  │        ├─ StudyRoomUserCard.tsx
+│  │        └─ StudyRoomUserProfileModal.tsx
+│  ├─ constants
+│  │  ├─ levelOptions.ts
+│  │  └─ studyOptions.ts
+│  ├─ data
+│  │  ├─ categoryData.ts
+│  │  ├─ dummyData.ts
+│  │  ├─ eventMockData.ts
+│  │  ├─ mockData.ts
+│  │  ├─ recruitStatusData.ts
+│  │  └─ recruitStatusMock.json
+│  ├─ hooks
+│  │  ├─ useClickOutside.ts
+│  │  ├─ useDrawingToolHook.ts
+│  │  └─ useLogin.ts
+│  ├─ index.css
+│  ├─ main.tsx
+│  ├─ mystudymockdata
+│  │  ├─ inboxMessageData.ts
+│  │  ├─ mockStudyData.json
+│  │  ├─ sentboxMessageData.ts
+│  │  ├─ studyCreateOptionsData.ts
+│  │  ├─ studyOptions.ts
+│  │  └─ studyRoomMockData.ts
+│  ├─ pages
+│  │  ├─ Layout
+│  │  │  ├─ Layout.tsx
+│  │  │  ├─ MessageLayout.tsx
+│  │  │  ├─ MyStudyLayout.tsx
+│  │  │  ├─ MypageLayout.tsx
+│  │  │  └─ ProtectedRoute.tsx
+│  │  ├─ NotFound.tsx
+│  │  ├─ auth
+│  │  │  ├─ AccountDeletePage.tsx
+│  │  │  ├─ FindEmailPage.tsx
+│  │  │  ├─ FindEmailSuccessPage.tsx
+│  │  │  ├─ FindPasswordPage.tsx
+│  │  │  ├─ MainPage.tsx
+│  │  │  ├─ RequireAdmin.tsx
+│  │  │  ├─ ResetPasswordPage.tsx
+│  │  │  ├─ ResetPasswordSuccessPage.tsx
+│  │  │  ├─ SignupPage.tsx
+│  │  │  ├─ SignupTermsPage.tsx
+│  │  │  └─ loginPage.tsx
+│  │  ├─ category
+│  │  │  ├─ CategoryDetailPage.tsx
+│  │  │  ├─ CategoryPage.tsx
+│  │  │  ├─ CategoryShortcutPage.tsx
+│  │  │  ├─ CustomRecommendPage.tsx
+│  │  │  └─ SideCategoryMenu.tsx
+│  │  ├─ contact
+│  │  │  └─ ContactPage.tsx
+│  │  ├─ event
+│  │  │  ├─ EventDetailPage.tsx
+│  │  │  ├─ EventListPage.tsx
+│  │  │  └─ EventMainPage.tsx
+│  │  ├─ mypage
+│  │  │  ├─ AccountSettingsPage.tsx
+│  │  │  ├─ MessageInboxPage.tsx
+│  │  │  ├─ MessageSentPage.tsx
+│  │  │  ├─ MessageWritePage.tsx
+│  │  │  └─ StudyPlannerPage.tsx
+│  │  ├─ mystudy
+│  │  │  ├─ MyStudyAppliedPage.tsx
+│  │  │  ├─ MyStudyCreatedPage.tsx
+│  │  │  ├─ MyStudyFavoritesPage.tsx
+│  │  │  ├─ MyStudyJoinedPage.tsx
+│  │  │  └─ StudyManagePage.tsx
+│  │  ├─ privacy
+│  │  │  └─ PrivacyPolicyPage.tsx
+│  │  ├─ search
+│  │  │  └─ SearchResultPage.tsx
+│  │  ├─ study
+│  │  │  ├─ StudyCategoryPage.tsx
+│  │  │  ├─ StudyCreatePage.tsx
+│  │  │  ├─ StudyCreateSuccessPage.tsx
+│  │  │  └─ StudyRoomPage.tsx
+│  │  └─ terms
+│  │     └─ TermsOfServicePage.tsx
+│  ├─ schemas
+│  │  └─ signupFormSchema.ts
+│  ├─ store
+│  │  ├─ useAttendance.ts
+│  │  ├─ useDismantledStudiesStore.ts
+│  │  ├─ useInboxMessageStore.ts
+│  │  ├─ useSentboxMessageStore.ts
+│  │  ├─ useTodoStore.ts
+│  │  └─ userInfoStore.ts
+│  ├─ types
+│  │  ├─ Applicant.ts
+│  │  ├─ RecruitApplicant.ts
+│  │  ├─ StudyCardDataType.ts
+│  │  ├─ circle.ts
+│  │  ├─ drawingTool.ts
+│  │  ├─ errorMessage.ts
+│  │  ├─ event.ts
+│  │  ├─ message.ts
+│  │  ├─ point.ts
+│  │  ├─ signupForm.ts
+│  │  ├─ study.ts
+│  │  ├─ studyCreateType.ts
+│  │  ├─ todo.ts
+│  │  └─ userData.ts
+│  ├─ utils
+│  │  ├─ cn.ts
+│  │  ├─ generateYearMonthOptions.ts
+│  │  ├─ getAccessToken.ts
+│  │  ├─ isAdmin.ts
+│  │  ├─ isKakaoUser.ts
+│  │  └─ toCustomDate.ts
+│  └─ vite-env.d.ts
+├─ tsconfig.app.json
+├─ tsconfig.json
+├─ tsconfig.node.json
+└─ vite.config.ts
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
 ```

--- a/src/api/soket.ts
+++ b/src/api/soket.ts
@@ -1,9 +1,11 @@
 let socket: WebSocket | null = null
 
 // study_id 기반으로 소켓 초기화
-export const initSocket = (studyId: string) => {
+export const initSocket = (studyId: string, token: string) => {
   // WebSocket 객체를 생성합니다.
-  socket = new WebSocket(`wss://storbit.o-r.kr/ws/study/${studyId}/`)
+  socket = new WebSocket(
+    `wss://storbit.o-r.kr/ws/study/${studyId}/?token=${token}`
+  )
 
   socket.onopen = () => {
     // console.log('WebSocket 연결 성공')

--- a/src/components/Layout/NavBar.tsx
+++ b/src/components/Layout/NavBar.tsx
@@ -61,14 +61,9 @@ export default function NavBar() {
       } else {
         refreshToken = userInfo?.refresh
       }
-      const res = await mainApi.post('/api/auth/logout/', {
+      await mainApi.post('/api/auth/logout/', {
         refresh: refreshToken,
       })
-      if (res.status === 205) {
-        useUserInfo.getState().setUserInfo(null)
-        setIsDropdownOpen(false)
-        navigate('/')
-      }
     } catch (error) {
       if (axios.isAxiosError(error)) {
         const status = error.response?.status
@@ -82,6 +77,10 @@ export default function NavBar() {
       } else {
         alert('네트워크 오류 또는 서버 오류가 발생했습니다.')
       }
+    } finally {
+      useUserInfo.getState().setUserInfo(null)
+      setIsDropdownOpen(false)
+      navigate('/')
     }
   }
 

--- a/src/components/study/studyRoomPage/KonvaWhiteBoard.tsx
+++ b/src/components/study/studyRoomPage/KonvaWhiteBoard.tsx
@@ -2,8 +2,10 @@
 import { disconnectSocket, initSocket } from '@/api/soket'
 import StudyRoomToolbox from '@/components/study/studyRoomPage/StudyRoomToolbox'
 import { useDrawingTool } from '@/hooks/useDrawingToolHook'
+import { useUserInfo } from '@/store/userInfoStore'
 import type { Circle as CircleType } from '@/types/circle'
 import type { ColoredLine } from '@/types/point'
+import { isKakaoUser } from '@/utils/isKakaoUser'
 import React, { useEffect, useRef, useState } from 'react'
 import { Stage, Layer, Line, Circle } from 'react-konva'
 import { useParams } from 'react-router-dom'
@@ -14,6 +16,8 @@ export default function Whiteboard({
   containerRef: React.RefObject<HTMLDivElement | null>
 }) {
   const { roomId: studyId } = useParams()
+  const userInfo = useUserInfo((state) => state.userInfo)
+
   const [toolName, setToolName] = useState<'pen' | 'circle' | 'fillCircle'>(
     'pen'
   )
@@ -33,8 +37,11 @@ export default function Whiteboard({
   const socketRef = useRef<WebSocket | null>(null)
 
   useEffect(() => {
-    if (!studyId) return
-    const socket = initSocket(studyId)
+    if (!studyId || !userInfo) return
+    const token = isKakaoUser(userInfo)
+      ? userInfo.access_token
+      : userInfo.access
+    const socket = initSocket(studyId, token)
     socketRef.current = socket
 
     // 서버에서 메시지를 받으면 실행될 핸들러
@@ -57,7 +64,7 @@ export default function Whiteboard({
       disconnectSocket()
       socketRef.current = null
     }
-  }, [studyId])
+  }, [studyId, userInfo])
   // console.log(lines)
   //화이트보드 사이즈 부모 사이즈 기준으로 적용
   useEffect(() => {


### PR DESCRIPTION

## ✅ PR 요약

- 관련 이슈 번호 : #154
- 작업요약 
  - 드로잉 이벤트에 유저 식별자 추가 및 멀티 유저 선 충돌 문제 해결
  - 로그아웃 시 오류발생시에도 유저정보 로컬에서 삭제

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

### 문제
- 현재 드로잉 이벤트에 유저 식별 정보가 없어, 다수 사용자가 동시에 작업할 경우
  마우스 이벤트가 섞여 처리됨
- 이로 인해 선이 순간 이동하거나 다른 유저의 선과 이어지는 문제가 발생함

### 해결 방법
- 웹소켓 URL 에 token 정보 포함하여 전송
- 서버에서 해당 token값 기준으로 이벤트를 분리하여 처리
- 유저별로 독립적인 드로잉 상태를 관리하도록 로직 수정

### 기대 효과
- 멀티 유저가 동시에 작업해도 선이 섞이지 않고 안정적으로 드로잉 가능

## 📸 스크린샷 (선택)

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
