### PR TITLE
✨ feat: 메인페이지 new study 카드 리스트 API 적용

### DIFF
--- a/src/common/StudyCard.tsx
+++ b/src/common/StudyCard.tsx
@@ -5,6 +5,7 @@ import { IoHeartOutline, IoHeartSharp } from 'react-icons/io5'
 import { HiOutlineUserGroup } from 'react-icons/hi2'
 import { BsClock } from 'react-icons/bs'
 import StudyTag from '@/common/tag/StudyTag'
+import { studyTypeOptions } from '@/mystudymockdata/studyCreateOptionsData'
 
 interface StudyCardProps {
   id?: number
@@ -12,11 +13,14 @@ interface StudyCardProps {
   title: string
   description: string
   memberCount?: number
+  maxMember?: number
   time?: string
   showBookmarkIcon?: boolean
   className?: string //외부에서 카드 전체 스타일을 확장할 때 사용 (Tailwind 클래스)
   variant?: 'horizontal' | 'vertical'
   thumbnailRatio?: string //썸네일 이미지 영역의 크기를 커스터마이징할 때 사용
+  level?: string
+  category?: number
   onClick?: () => void
 }
 
@@ -26,16 +30,18 @@ const StudyCard = ({
   title,
   description,
   memberCount,
+  maxMember,
   time,
   showBookmarkIcon,
   className,
   variant = 'vertical',
   thumbnailRatio,
+  level,
+  category,
   onClick,
 }: StudyCardProps) => {
   const isVertical = variant === 'vertical'
   const [isBookmarked, setIsBookmarked] = useState(false)
-
   const imageClass = thumbnailRatio
     ? thumbnailRatio
     : isVertical
@@ -43,7 +49,6 @@ const StudyCard = ({
       : 'w-[440px] h-[256px]'
 
   const wrapperClass = isVertical ? 'w-[320px]' : 'w-[440px]'
-
   const handleBookmarkClick = (e: React.MouseEvent) => {
     e.stopPropagation() // 카드 클릭 방지
     setIsBookmarked((prev) => !prev)
@@ -52,6 +57,14 @@ const StudyCard = ({
   const handleCardClick = () => {
     Navigate(`/study/detail/${id}`)
     if (onClick) onClick()
+  }
+  const getCategoryValue = (value: number | undefined) => {
+    const option = studyTypeOptions.find((item) => item.value === value)
+    if (!option) return null
+
+    // "IT · 프로그래밍 > 개발 교육과정" → ["IT · 프로그래밍 ", " 개발 교육과정"]
+    const parts = option.label.split('>')
+    return parts[parts.length - 1].trim()
   }
   return (
     <div
@@ -62,8 +75,11 @@ const StudyCard = ({
       <div className={cn(imageClass, 'relative rounded-[8px] overflow-hidden')}>
         {/* 태그 박스 */}
         <div className="absolute top-[16px] right-[16px] flex gap-[4px] z-10">
-          <StudyTag variant="level" text="초급" />
-          <StudyTag variant="category" text="프로그래밍" />
+          <StudyTag variant="level" text={level ?? '초급'} />
+          <StudyTag
+            variant="category"
+            text={getCategoryValue(category) ?? '프로그래밍'}
+          />
         </div>
 
         {/* 이미지 */}
@@ -100,7 +116,9 @@ const StudyCard = ({
             {memberCount !== undefined && (
               <div className="flex items-center gap-1">
                 <HiOutlineUserGroup className="w-[16px] h-[16px]" />
-                <span>{memberCount}/10</span>
+                <span>
+                  {memberCount}/{maxMember}
+                </span>
               </div>
             )}
             {time && (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { BrowserRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const queryClient = new QueryClient({})
 
 const enableMocking = async () => {
   if (!import.meta.env.DEV) return
@@ -13,8 +16,10 @@ const enableMocking = async () => {
 
 enableMocking().then(() => {
   createRoot(document.getElementById('root')!).render(
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   )
 })

--- a/src/mystudymockdata/studyCreateOptionsData.ts
+++ b/src/mystudymockdata/studyCreateOptionsData.ts
@@ -13,15 +13,15 @@ export const studyCategoryOptions = [
 
 export const studyTypeOptions = [
   {
-    value: 'IT · 프로그래밍 > 개발 교육과정',
+    value: 1,
     label: 'IT · 프로그래밍 > 개발 교육과정',
   },
   {
-    value: 'IT · 프로그래밍 > 커리어 개발',
+    value: 2,
     label: 'IT · 프로그래밍 > 커리어 개발',
   },
   {
-    value: 'IT · 프로그래밍 > 개발 프로젝트',
+    value: 3,
     label: 'IT · 프로그래밍 > 개발 프로젝트',
   },
 ]

--- a/src/pages/auth/MainPage.tsx
+++ b/src/pages/auth/MainPage.tsx
@@ -5,10 +5,24 @@ import MainBanner from '@/components/Main/MainBanner'
 import CategoryShortcutTabs from '@/components/Main/CategoryShortcutTabs'
 import ArrowNavigation from '@/common/ArrowNavigation'
 import JoinedStudySection from '@/components/Main/JoinedStudySection'
+import { useQuery } from '@tanstack/react-query'
+import { mainApi } from '@/api/mainApi'
+import type { StudyRoomsResponse } from '@/types/StudyCardDataType'
+import { formatSchedule } from '@/utils/formatSchedule'
+import { isoToKoreanTime } from '@/utils/isoToKoreanTime'
 
 const isLoggedIn = false // 추후 로그인 구현 시 교체 예정
 
 const MainPage = () => {
+  const imgBaseUrl = import.meta.env.VITE_API_MAIN_URL
+
+  const { data: newData = [] } = useQuery({
+    queryKey: ['eventList', { type: 'new' }],
+    queryFn: async () => {
+      const response = await mainApi.get<StudyRoomsResponse>('/api/study-rooms')
+      return response.data.results
+    },
+  })
   // 슬라이드 인덱스 상태
   const [hotIndex, setHotIndex] = useState(0)
   const [newIndex, setNewIndex] = useState(0)
@@ -21,7 +35,7 @@ const MainPage = () => {
 
   // 데이터
   const hotData = dummyData.slice(0, 10)
-  const newData = dummyData.slice(0, 10)
+  // const newData = dummyData.slice(0, 10)
   const steadyData = dummyData.slice(0, 10)
 
   // 인덱스 최대값 보정
@@ -112,14 +126,23 @@ const MainPage = () => {
               }}
             >
               {newData.map((item, index) => (
-                <div key={`new-${index}`} className="shrink-0 w-[440px]">
+                <div
+                  key={`new-${index}`}
+                  className="shrink-0 w-[440px] cursor-pointer"
+                >
                   <StudyCard
                     id={item.id}
-                    imageUrl={item.imageUrl}
+                    imageUrl={`${imgBaseUrl}${item.thumbnail_url}`}
                     title={item.title}
                     description={item.description}
-                    memberCount={item.memberCount}
-                    time={item.time}
+                    memberCount={item.accepted_count}
+                    maxMember={item.member}
+                    time={formatSchedule(
+                      item.schedule,
+                      isoToKoreanTime(item.start_time)
+                    )}
+                    level={item.level}
+                    category={item.category}
                     variant="horizontal"
                     thumbnailRatio="w-[440px] h-[256px]"
                     className="w-[440px]"
@@ -155,7 +178,10 @@ const MainPage = () => {
               }}
             >
               {steadyData.map((item, index) => (
-                <div key={`steady-${index}`} className="shrink-0 w-[320px]">
+                <div
+                  key={`steady-${index}`}
+                  className="shrink-0 w-[320px] cursor-pointer"
+                >
                   <StudyCard
                     id={item.id}
                     imageUrl={item.imageUrl}

--- a/src/types/StudyCardDataType.ts
+++ b/src/types/StudyCardDataType.ts
@@ -1,3 +1,4 @@
+//mockData 타입
 export interface StudyCardDataType {
   id: number
   userProfile: string | null
@@ -5,4 +6,33 @@ export interface StudyCardDataType {
   dailyMissions: string[]
   isMe: boolean
   isLeader: boolean
+}
+
+// 실제 서버 API 용 타입 (작성자 : yh)
+export type StudyCardData = {
+  id: number
+  title: string
+  description: string
+  thumbnail_url: string | null
+  type: string
+  max_wait_member: number
+  level: string
+  gender: 'male' | 'female' | 'all'
+  category: number // 1 , 2, 3
+  category_name: string
+  schedule: string
+  start_time: Date | string
+  member: number
+  leader_name: string
+  accepted_count: number
+  is_live: boolean
+  member_count: number
+  status: string
+}
+
+export interface StudyRoomsResponse {
+  count: number
+  next: string | null
+  previous: string | null
+  results: StudyCardData[]
 }

--- a/src/utils/formatSchedule.ts
+++ b/src/utils/formatSchedule.ts
@@ -1,0 +1,22 @@
+const dayMap: Record<string, string> = {
+  월요일: '월',
+  화요일: '화',
+  수요일: '수',
+  목요일: '목',
+  금요일: '금',
+  토요일: '토',
+  일요일: '일',
+}
+
+export function formatSchedule(daysStr: string, timeStr: string) {
+  return (
+    daysStr
+      .replace(/포함/g, '') // '포함' 제거
+      .split(',') // , 로 나누기
+      .map((day) => {
+        const trimmed = day.trim()
+        return dayMap[trimmed] || trimmed // 요일이면 변환, 아니면 그대로
+      })
+      .join(', ') + ` ${timeStr}`
+  )
+}

--- a/src/utils/isoToKoreanTime.ts
+++ b/src/utils/isoToKoreanTime.ts
@@ -1,0 +1,10 @@
+export function isoToKoreanTime(isoString: string | Date) {
+  const date = new Date(isoString)
+
+  // 한국 시간대(KST, UTC+9)로 보정
+  const koreanHour = date.getHours() // 이미 UTC → 로컬 변환됨 (만약 서버에서 UTC 그대로라면 +9 더해줘야 함)
+  const hour12 = koreanHour % 12 === 0 ? 12 : koreanHour % 12
+  const period = koreanHour < 12 ? '오전' : '오후'
+
+  return `${period} ${hour12}시`
+}


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #157
- 작업요약 : 메일 페이지 new Study API 연결하여 불러오기

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 메인 메이지 new Study 카드 부분 API 연결하여 적용 하였습니다.- 


## 📸 스크린샷 (선택)
<img width="800" alt="CleanShot 2025-08-21 at 10 43 26" src="https://github.com/user-attachments/assets/998630c0-0204-4958-bebe-10272c0837e3" />



<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
