### PR TITLE
🐛 fix: 로그인 후 약관 페이지 스타일 수정

### DIFF
--- a/src/common/InputField.tsx
+++ b/src/common/InputField.tsx
@@ -34,7 +34,7 @@ export default function InputField({
   return (
     <div
       className={cn(
-        'flex flex-col gap-1.5 w-full',
+        'flex flex-col gap-1.5',
         isCheckbox && 'flex-row items-center'
       )}
     >

--- a/src/pages/study/StudyCreatePage.tsx
+++ b/src/pages/study/StudyCreatePage.tsx
@@ -152,25 +152,23 @@ export default function StudyCreatePage() {
         </h1>
 
         {/* 스터디 이름 */}
-        <div className="flex flex-col gap-[16px] mt-[40px] w-full">
+        <div className="flex flex-col gap-[16px] mt-[40px]">
           <label className="text-[16px]">
             스터디 이름<span className="text-alertText">*</span>
           </label>
-          <div className="flex gap-[8px] w-full">
-            <InputField
-              className={cn(
-                'w-full h-[48px] placeholder:text-text4',
-                !errors.title &&
-                  watch('title')?.trim() !== '' &&
-                  'border-text text-text'
-              )}
-              error={errors.title?.message}
-              placeholder="이름을 입력해주세요"
-              {...register('title', {
-                required: '스터디 이름을 입력해주세요',
-              })}
-            />
-          </div>
+          <InputField
+            className={cn(
+              'w-full h-[48px] placeholder:text-text4',
+              !errors.title &&
+                watch('title')?.trim() !== '' &&
+                'border-text text-text'
+            )}
+            error={errors.title?.message}
+            placeholder="이름을 입력해주세요"
+            {...register('title', {
+              required: '스터디 이름을 입력해주세요',
+            })}
+          />
         </div>
 
         {/* 스터디 소개 */}


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #163
- 작업요약 : 약관 페이지 스타일링 오류 해결

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 회원가입 후 이동하는 약관 페이지에서 발생한 스타일 오류 수정
- 체크 박스 폭 오류로 text 가 우측으로 밀리는 문제 수정
- `InputField.tsx` 공통 컴포넌트의 스타일 `w-full` 속성 삭제 후 페이지 컴포넌트에서 스타일 수정
- 
## 📸 스크린샷 (선택)

<변경 전>
<img width="400" alt="CleanShot 2025-08-23 at 13 22 36@2x" src="https://github.com/user-attachments/assets/5ca602b6-6d48-407a-afa3-8bdbe19b1427" />

<변경 후>
<img width="400" alt="CleanShot 2025-08-23 at 13 22 09@2x" src="https://github.com/user-attachments/assets/a7ad9179-be54-4d4e-88f5-4607afff7383" />



## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
